### PR TITLE
📝 🎨 VL53L0X changes

### DIFF
--- a/VL53L0X/README.md
+++ b/VL53L0X/README.md
@@ -6,6 +6,14 @@ Testado com projetos do STM32CubeMX, usando a biblioteca HAL, e por padrão usa 
 
 -------
 
+### Changelog
+
+* 09/2018
+  * Change ADDRESS_DEFAULT to VL53L0X_DEFAULT_ADDRESS to avoid name collisions
+  * Improved in-file documentation
+  * Add VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE, VL53L0X_VCSEL_FINAL_RANGE constant for easier changing
+  * Add VL53L0X_TIMEOUT_RETURN_VALUE
+
 ### Funções disponiveis
 
 * `uint8_t vl53l0x_init()`
@@ -38,26 +46,22 @@ Testado com projetos do STM32CubeMX, usando a biblioteca HAL, e por padrão usa 
 
 ```c
 // vl53l0x.h
-13    #define _VL53L0X_H_
-14
-15    // SPECIFIC INCLUDES HERE
-16
-17    #define ADDRESS_DEFAULT (0x52)
+13    #ifndef _VL53L0X_H_
+14    #define _VL53L0X_H_
+15
+16    // SPECIFIC INCLUDES HERE
+17
+18    /*****************************************
 ```
 
-Dois valores também podem ser modificados em `vl53l0x.c` para mudar o comportamento dos sensores inicializados:
-
+Também em `vl53l0x.h` pode-se mudar as constantes de acordo com o projeto:
 ```c
-// vl53l0x.c
-282   setVcselPulsePeriod(VcselPeriodPreRange, 18);
-283   setVcselPulsePeriod(VcselPeriodFinalRange, 14);
+25    #define VL53L0X_I2C_HANDLER hi2c1      /**< I2C handler */
+26
+27    //! @see setVcselPulsePeriod
+28    #define VL53L0X_VCSEL_PRE_RANGE 18
+29    #define VL53L0X_VCSEL_FINAL_RANGE 14
 ```
-
-Do repositório da Pololu:
-
-> Pre: 12 to 18 (initialized to 14 by default)
->
-> Final: 8 to 14 (initialized to 10 by default)
 
 -----------
 

--- a/VL53L0X/vl53l0x.c
+++ b/VL53L0X/vl53l0x.c
@@ -1,39 +1,151 @@
 /**
- * Arquivo: vl53l0x.c
+ * @file vl53l0x.c
  *
- * Autor: Daniel Nery Silva de Oliveira
+ * @author Daniel Nery <daniel.nery@thunderatz.org>
  *
  * Equipe ThundeRatz de Robotica
- * 03/2017
+ *
+ * @date 03/2017
+ *
+ * @see https://github.com/pololu/vl53l0x-arduino
  */
-
-//! Ver: https://github.com/pololu/vl53l0x-arduino
 
 #include "vl53l0x.h"
 #include "string.h"
 
-#define decodeVcselPeriod(reg_val)          (((reg_val) + 1) << 1)
-#define encodeVcselPeriod(period_pclks)     (((period_pclks) >> 1) - 1)
-#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304* (vcsel_period_pclks)* 1655) + 500) / 1000)
+/*****************************************
+ * Private Constants
+ *****************************************/
 
-#define startTimeout()        (timeout_start_ms = HAL_GetTick())
+#define VL53L0X_I2C_TIMEOUT 1000
+
+/*****************************************
+ * Private Macros
+ *****************************************/
+
+#define decodeVcselPeriod(reg_val) (((reg_val) + 1) << 1)
+#define encodeVcselPeriod(period_pclks) (((period_pclks) >> 1) - 1)
+#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks)*1655) + 500) / 1000)
+
+#define startTimeout() (timeout_start_ms = HAL_GetTick())
 #define checkTimeoutExpired() (io_timeout > 0 && ((uint16_t)HAL_GetTick() - timeout_start_ms) > io_timeout)
 
-#define TIMEOUT 1000
+/*****************************************
+ * Private Types
+ *****************************************/
 
 typedef struct {
-    uint8_t tcc, msrc, dss, pre_range, final_range;
+    uint8_t tcc;
+    uint8_t msrc;
+    uint8_t dss;
+    uint8_t pre_range;
+    uint8_t final_range;
 } SequenceStepEnables;
 
 typedef struct {
-    uint16_t pre_range_vcsel_period_pclks, final_range_vcsel_period_pclks;
-    uint16_t msrc_dss_tcc_mclks, pre_range_mclks, final_range_mclks;
-    uint32_t msrc_dss_tcc_us,    pre_range_us,    final_range_us;
+    uint16_t pre_range_vcsel_period_pclks;
+    uint16_t final_range_vcsel_period_pclks;
+    uint16_t msrc_dss_tcc_mclks;
+    uint16_t pre_range_mclks;
+    uint16_t final_range_mclks;
+    uint32_t msrc_dss_tcc_us;
+    uint32_t pre_range_us;
+    uint32_t final_range_us;
 } SequenceStepTimeouts;
 
-static uint8_t address     = ADDRESS_DEFAULT;
-static uint8_t did_timeout = 0;
-static uint16_t io_timeout = 500;
+typedef enum {
+    SYSRANGE_START = 0x00,
+
+    SYSTEM_THRESH_HIGH = 0x0C,
+    SYSTEM_THRESH_LOW = 0x0E,
+
+    SYSTEM_SEQUENCE_CONFIG = 0x01,
+    SYSTEM_RANGE_CONFIG = 0x09,
+    SYSTEM_INTERMEASUREMENT_PERIOD = 0x04,
+
+    SYSTEM_INTERRUPT_CONFIG_GPIO = 0x0A,
+
+    GPIO_HV_MUX_ACTIVE_HIGH = 0x84,
+
+    SYSTEM_INTERRUPT_CLEAR = 0x0B,
+
+    RESULT_INTERRUPT_STATUS = 0x13,
+    RESULT_RANGE_STATUS = 0x14,
+
+    RESULT_CORE_AMBIENT_WINDOW_EVENTS_RTN = 0xBC,
+    RESULT_CORE_RANGING_TOTAL_EVENTS_RTN = 0xC0,
+    RESULT_CORE_AMBIENT_WINDOW_EVENTS_REF = 0xD0,
+    RESULT_CORE_RANGING_TOTAL_EVENTS_REF = 0xD4,
+    RESULT_PEAK_SIGNAL_RATE_REF = 0xB6,
+
+    ALGO_PART_TO_PART_RANGE_OFFSET_MM = 0x28,
+
+    I2C_SLAVE_DEVICE_ADDRESS = 0x8A,
+
+    MSRC_CONFIG_CONTROL = 0x60,
+
+    PRE_RANGE_CONFIG_MIN_SNR = 0x27,
+    PRE_RANGE_CONFIG_VALID_PHASE_LOW = 0x56,
+    PRE_RANGE_CONFIG_VALID_PHASE_HIGH = 0x57,
+    PRE_RANGE_MIN_COUNT_RATE_RTN_LIMIT = 0x64,
+
+    FINAL_RANGE_CONFIG_MIN_SNR = 0x67,
+    FINAL_RANGE_CONFIG_VALID_PHASE_LOW = 0x47,
+    FINAL_RANGE_CONFIG_VALID_PHASE_HIGH = 0x48,
+    FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT = 0x44,
+
+    PRE_RANGE_CONFIG_SIGMA_THRESH_HI = 0x61,
+    PRE_RANGE_CONFIG_SIGMA_THRESH_LO = 0x62,
+
+    PRE_RANGE_CONFIG_VCSEL_PERIOD = 0x50,
+    PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI = 0x51,
+    PRE_RANGE_CONFIG_TIMEOUT_MACROP_LO = 0x52,
+
+    SYSTEM_HISTOGRAM_BIN = 0x81,
+    HISTOGRAM_CONFIG_INITIAL_PHASE_SELECT = 0x33,
+    HISTOGRAM_CONFIG_READOUT_CTRL = 0x55,
+
+    FINAL_RANGE_CONFIG_VCSEL_PERIOD = 0x70,
+    FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI = 0x71,
+    FINAL_RANGE_CONFIG_TIMEOUT_MACROP_LO = 0x72,
+    CROSSTALK_COMPENSATION_PEAK_RATE_MCPS = 0x20,
+
+    MSRC_CONFIG_TIMEOUT_MACROP = 0x46,
+
+    SOFT_RESET_GO2_SOFT_RESET_N = 0xBF,
+    IDENTIFICATION_MODEL_ID = 0xC0,
+    IDENTIFICATION_REVISION_ID = 0xC2,
+
+    OSC_CALIBRATE_VAL = 0xF8,
+
+    GLOBAL_CONFIG_VCSEL_WIDTH = 0x32,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_0 = 0xB0,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_1 = 0xB1,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_2 = 0xB2,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_3 = 0xB3,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_4 = 0xB4,
+    GLOBAL_CONFIG_SPAD_ENABLES_REF_5 = 0xB5,
+
+    GLOBAL_CONFIG_REF_EN_START_SELECT = 0xB6,
+    DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD = 0x4E,
+    DYNAMIC_SPAD_REF_EN_START_OFFSET = 0x4F,
+    POWER_MANAGEMENT_GO1_POWER_FORCE = 0x80,
+
+    VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV = 0x89,
+
+    ALGO_PHASECAL_LIM = 0x30,
+    ALGO_PHASECAL_CONFIG_TIMEOUT = 0x30,
+} vl53l0x_regAddr;
+
+typedef enum { VcselPeriodPreRange, VcselPeriodFinalRange } vcselPeriodType;
+
+/*****************************************
+ * Private Variables
+ *****************************************/
+
+static uint8_t address = VL53L0X_DEFAULT_ADDRESS; /**< Current Address */
+static uint8_t did_timeout = 0;                   /**< Timeout detection */
+static uint16_t io_timeout = 500;                 /**< Timeout in miliseconds */
 
 static uint8_t stop_variable;
 static uint8_t timeout_start_ms;
@@ -41,32 +153,176 @@ static uint32_t measurement_timing_budget_us;
 
 static HAL_StatusTypeDef status;
 
+/*****************************************
+ * Private Function Prototypes
+ *****************************************/
+
+/**
+ * @brief HAL I2C wrapper functions.
+ */
 static void writeReg(uint8_t reg, uint8_t val);
 static void writeReg16(uint8_t reg, uint16_t val);
 static void writeReg32(uint8_t reg, uint32_t val);
 static void writeMulti(uint8_t reg, uint8_t* src, uint8_t count);
-
 static uint8_t readReg(uint8_t reg);
 static uint16_t readReg16(uint8_t reg);
 static uint32_t readReg32(uint8_t reg);
 static void readMulti(uint8_t reg, uint8_t* dst, uint8_t count);
 
+/**
+ * @brief Get reference SPAD (single photon avalanche diode) count and type.
+ *
+ * @note based on VL53L0X_get_info_from_device(), but only gets reference SPAD count and type.
+ *
+ * @param count Pointer where SPAD count will be stored.
+ * @param type_is_aperture Pointer where SPAD type will be stored.
+ *
+ * @return 0 on failure, 1 on success.
+ */
 uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture);
 
+/**
+ * @brief Set the measurement timing budget
+ *
+ * @note Time allowed for one measurement; the ST API and this library take
+ *       care of splitting the timing budget among the sub-steps in the ranging sequence.
+ *       A longer timing budget allows for more accurate measurements. Increasing the
+ *       budget by a factor of N decreases the range measurement standard deviation
+ *       by a factor of sqrt(N). Defaults to about 33 milliseconds; the minimum is 20 ms.
+ *       based on VL53L0X_set_measurement_timing_budget_micro_seconds()
+ *
+ * @param budget_us Timing budget in microseconds.
+ *
+ * @return 0 on failure, 1 on success.
+ */
 uint8_t setMeasurementTimingBudget(uint32_t budget_us);
+
+/**
+ * @brief Get the measurement timing budget
+ *
+ * @note based on VL53L0X_get_measurement_timing_budget_micro_seconds()
+ *
+ * @return Timing budget in microseconds.
+ */
 uint32_t getMeasurementTimingBudget();
 
+/**
+ * @brief Set the VCSEL (vertical cavity surface emitting laser) pulse period for the
+ *        given period type (pre-range or final range) to the given value in PCLKs.
+ *
+ * @note Longer periods seem to increase the potential range of the sensor.
+ *       Valid values are (even numbers only):
+ *        pre:  12 to 18 (initialized default: 14)
+ *        final: 8 to 14 (initialized default: 10)
+ *       based on VL53L0X_set_vcsel_pulse_period()
+ *
+ * @param type Period Type (VcselPeriodPreRange or VcselPeriodFinalRange).
+ * @param period_pclks Period in PCLKs
+ *
+ * @return 0 on failure, 1 on success.
+ */
 uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks);
+
+/**
+ * @brief Get the VCSEL pulse period
+ *
+ * @note based on VL53L0X_get_vcsel_pulse_period()
+ *
+ * @param type Period Type (VcselPeriodPreRange or VcselPeriodFinalRange).
+ *
+ * @return Period in PCLKs.
+ */
 uint8_t getVcselPulsePeriod(vcselPeriodType type);
 
+/**
+ * @brief Get sequence step enables
+ *
+ * @note based on VL53L0X_GetSequenceStepEnables()
+ *
+ * @param enables Pointer to SequenceStepEnables struct where
+ *        values will be stored.
+ */
 void getSequenceStepEnables(SequenceStepEnables* enables);
+
+/**
+ * @brief Get sequence step timeouts
+ *
+ * @note based on get_sequence_step_timeout(), but gets all timeouts
+ *       instead of just the requested one, and also stores
+ *       intermediate values
+ *
+ * @param enables Pointer to initialized SequenceStepEnables struct;
+ * @param timeout Pointer to SequenceStepTimeouts struct where values
+ *        will be stored.
+ */
 void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts);
 
+/**
+ * @brief Decode sequence step timeout in MCLKs from register value.
+ *
+ * @note Based on VL53L0X_decode_timeout()
+ * @note The original function returned a uint32_t, but the return value is
+ *       always stored in a uint16_t.
+ *
+ * @param reg_val Register value.
+ *
+ * @return Decoded value in MCLKs.
+ */
 uint16_t decodeTimeout(uint16_t reg_val);
+
+/**
+ * @brief Encode sequence step timeout register value from timeout in MCLKs.
+ *
+ * @note Based on VL53L0X_encode_timeout()
+ * @note the original function took a uint32_t, but the argument passed to it
+ *       is always a uint16_t.
+ *
+ * @param timeout_mclks Timeout in MCLKs.
+ *
+ * @return Encoded value.
+ */
 uint16_t encodeTimeout(uint16_t timeout_mclks);
+
+/**
+ * @brief Convert sequence step timeout from MCLKs to microseconds with given VCSEL
+ *        period in PCLKs
+ *
+ * @note Based on VL53L0X_calc_timeout_us().
+
+ * @param timeout_period_mclks Timeout in MCLKs.
+ * @param vcsel_period_pclks VCSEL period in PCLKs.
+ *
+ * @return Timeout in microseconds.
+ */
 uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks);
+
+/**
+ * @brief Convert sequence step timeout from microseconds to MCLKs with given VCSEL
+ *        period in PCLKs
+ *
+ * @note Based on VL53L0X_calc_timeout_mclks().
+
+ * @param timeout_period_us Timeout in microseconds.
+ * @param vcsel_period_pclks VCSEL period in PCLKs.
+ *
+ * @return Timeout in MCLKs.
+ */
 uint32_t timeoutMicrosecondsToMclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks);
+
+/**
+ * @brief Performs Calibration
+ *
+ * @note Based on VL53L0X_perform_single_ref_calibration().
+
+ * @param vhv_init_byte
+ *
+ * @return 0 on failure, 1 on success.
+ */
 uint8_t performSingleRefCalibration(uint8_t vhv_init_byte);
+
+/*****************************************
+ * Public Function Body Definitions
+ *****************************************/
 
 void vl53l0x_setCurrentAddress(uint8_t new_addr) {
     address = new_addr;
@@ -74,7 +330,6 @@ void vl53l0x_setCurrentAddress(uint8_t new_addr) {
 
 void vl53l0x_setDevAddress(uint8_t new_addr) {
     writeReg(I2C_SLAVE_DEVICE_ADDRESS, (new_addr >> 1) & 0x7F);
-    // address = new_addr;
 }
 
 uint8_t vl53l0x_init() {
@@ -90,7 +345,8 @@ uint8_t vl53l0x_init() {
     writeReg(0xFF, 0x00);
     writeReg(0x80, 0x00);
 
-    // disable SIGNAL_RATE_MSRC (bit 1) and SIGNAL_RATE_PRE_RANGE (bit 4) limit checks
+    // disable SIGNAL_RATE_MSRC (bit 1) and SIGNAL_RATE_PRE_RANGE (bit 4) limit
+    // checks
     writeReg(MSRC_CONFIG_CONTROL, readReg(MSRC_CONFIG_CONTROL) | 0x12);
 
     writeReg16(FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT, 0.25 * (1 << 7));
@@ -104,8 +360,8 @@ uint8_t vl53l0x_init() {
     if (!getSpadInfo(&spad_count, &spad_type_is_aperture))
         return 0;
 
-    // The SPAD map (RefGoodSpadMap) is read by VL53L0X_get_info_from_device() in
-    // the API, but the same data seems to be more easily readable from
+    // The SPAD map (RefGoodSpadMap) is read by VL53L0X_get_info_from_device()
+    // in the API, but the same data seems to be more easily readable from
     // GLOBAL_CONFIG_SPAD_ENABLES_REF_0 through _6, so read it from there
     uint8_t ref_spad_map[6];
     readMulti(GLOBAL_CONFIG_SPAD_ENABLES_REF_0, ref_spad_map, 6);
@@ -118,7 +374,7 @@ uint8_t vl53l0x_init() {
     writeReg(0xFF, 0x00);
     writeReg(GLOBAL_CONFIG_REF_EN_START_SELECT, 0xB4);
 
-    uint8_t first_spad_to_enable = spad_type_is_aperture ? 12 : 0; // 12 is the first aperture spad
+    uint8_t first_spad_to_enable = spad_type_is_aperture ? 12 : 0;  // 12 is the first aperture spad
     uint8_t spads_enabled = 0;
 
     for (uint8_t i = 0; i < 48; i++) {
@@ -235,7 +491,8 @@ uint8_t vl53l0x_init() {
     // -- VL53L0X_SetGpioConfig() begin
 
     writeReg(SYSTEM_INTERRUPT_CONFIG_GPIO, 0x04);
-    writeReg(GPIO_HV_MUX_ACTIVE_HIGH, readReg(GPIO_HV_MUX_ACTIVE_HIGH) & ~0x10); // active low
+    writeReg(GPIO_HV_MUX_ACTIVE_HIGH,
+             readReg(GPIO_HV_MUX_ACTIVE_HIGH) & ~0x10);  // active low
     writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
 
     // -- VL53L0X_SetGpioConfig() end4
@@ -279,43 +536,115 @@ uint8_t vl53l0x_init() {
 
     // VL53L0X_PerformRefCalibration() end
 
-    setVcselPulsePeriod(VcselPeriodPreRange, 18);
-    setVcselPulsePeriod(VcselPeriodFinalRange, 14);
+    setVcselPulsePeriod(VcselPeriodPreRange, VL53L0X_VCSEL_PRE_RANGE);
+    setVcselPulsePeriod(VcselPeriodFinalRange, VL53L0X_VCSEL_FINAL_RANGE);
 
     return 1;
 }
 
-// aux functions
+void vl53l0x_startContinuous(uint32_t period_ms) {
+    writeReg(0x80, 0x01);
+    writeReg(0xFF, 0x01);
+    writeReg(0x00, 0x00);
+    writeReg(0x91, stop_variable);
+    writeReg(0x00, 0x01);
+    writeReg(0xFF, 0x00);
+    writeReg(0x80, 0x00);
+
+    if (period_ms != 0) {
+        // continuous timed mode
+        // VL53L0X_SetInterMeasurementPeriodMilliSeconds() begin
+        uint16_t osc_calibrate_val = readReg16(OSC_CALIBRATE_VAL);
+        if (osc_calibrate_val != 0)
+            period_ms *= osc_calibrate_val;
+
+        writeReg32(SYSTEM_INTERMEASUREMENT_PERIOD, period_ms);
+        // VL53L0X_SetInterMeasurementPeriodMilliSeconds() end
+
+        writeReg(SYSRANGE_START, 0x04);  // VL53L0X_REG_SYSRANGE_MODE_TIMED
+    } else {
+        // continuous back-to-back mode
+        writeReg(SYSRANGE_START, 0x02);  // VL53L0X_REG_SYSRANGE_MODE_BACKTOBACK
+    }
+}
+
+// Stop continuous measurements
+// based on VL53L0X_StopMeasurement()
+void vl53l0x_stopContinuous() {
+    writeReg(SYSRANGE_START, 0x01);  // VL53L0X_REG_SYSRANGE_MODE_SINGLESHOT
+
+    writeReg(0xFF, 0x01);
+    writeReg(0x00, 0x00);
+    writeReg(0x91, 0x00);
+    writeReg(0x00, 0x01);
+    writeReg(0xFF, 0x00);
+}
+
+// Returns a range reading in millimeters when continuous mode is active
+uint16_t vl53l0x_getRange() {
+    startTimeout();
+    while ((readReg(RESULT_INTERRUPT_STATUS) & 0x07) == 0) {
+        if (checkTimeoutExpired()) {
+            did_timeout = 1;
+            return VL53L0X_TIMEOUT_RETURN_VALUE;
+        }
+    }
+
+    // assumptions: Linearity Corrective Gain is 1000 (default);
+    // fractional ranging is not enabled
+    uint16_t range = readReg16(RESULT_RANGE_STATUS + 10);
+
+    writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
+
+    return range;
+}
+
+uint16_t vl53l0x_getRangeSingle() {
+    writeReg(0x80, 0x01);
+    writeReg(0xFF, 0x01);
+    writeReg(0x00, 0x00);
+    writeReg(0x91, stop_variable);
+    writeReg(0x00, 0x01);
+    writeReg(0xFF, 0x00);
+    writeReg(0x80, 0x00);
+
+    writeReg(SYSRANGE_START, 0x01);
+
+    // "Wait until start bit has been cleared"
+    startTimeout();
+    while (readReg(SYSRANGE_START) & 0x01) {
+        if (checkTimeoutExpired()) {
+            did_timeout = 1;
+            return VL53L0X_TIMEOUT_RETURN_VALUE;
+        }
+    }
+
+    return vl53l0x_getRange();
+}
+
+/*****************************************
+ * Public Function Body Definitions
+ *****************************************/
 
 void writeReg(uint8_t reg, uint8_t val) {
-    uint8_t bytes[2] = {
-        reg,
-        val
-    };
+    uint8_t bytes[2] = {reg, val};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 2, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 2, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+        ;
 }
 
 void writeReg16(uint8_t reg, uint16_t val) {
-    uint8_t bytes[3] = {
-        reg,
-        (val >> 8) & 0xFF,
-         val       & 0xFF
-    };
+    uint8_t bytes[3] = {reg, (val >> 8) & 0xFF, val & 0xFF};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 3, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 3, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+        ;
 }
 
 void writeReg32(uint8_t reg, uint32_t val) {
-    uint8_t bytes[5] = {
-        reg,
-        (val >> 24) & 0xFF,
-        (val >> 16) & 0xFF,
-        (val >>  8) & 0xFF,
-         val        & 0xFF
-    };
+    uint8_t bytes[5] = {reg, (val >> 24) & 0xFF, (val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 5, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 5, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+        ;
 }
 
 void writeMulti(uint8_t reg, uint8_t* src, uint8_t count) {
@@ -323,19 +652,21 @@ void writeMulti(uint8_t reg, uint8_t* src, uint8_t count) {
         return;
 
     count++;
-    uint8_t bytes[32] = { 0	};
+    uint8_t bytes[32] = {0};
     bytes[0] = reg;
     for (uint8_t i = 1; i < count; i++)
-        bytes[i] = src[i-1];
+        bytes[i] = src[i - 1];
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), count, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), count, VL53L0X_I2C_TIMEOUT) !=
+           HAL_OK)
+        ;
 }
-
 
 uint8_t readReg(uint8_t reg) {
     uint8_t val;
 
-    if((status = HAL_I2C_Mem_Read(&hi2c1, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1, TIMEOUT)) != HAL_OK)
+    if ((status = HAL_I2C_Mem_Read(&VL53L0X_I2C_HANDLER, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1,
+                                   VL53L0X_I2C_TIMEOUT)) != HAL_OK)
         return 0;
 
     return val;
@@ -351,19 +682,13 @@ uint32_t readReg32(uint8_t reg) {
     uint8_t val[4];
     readMulti(reg, val, 4);
 
-    return (uint32_t)val[0] << 24 |
-           (uint32_t)val[1] << 16 |
-           (uint16_t)val[2] <<  8 |
-                        val[3];
+    return (uint32_t)val[0] << 24 | (uint32_t)val[1] << 16 | (uint16_t)val[2] << 8 | val[3];
 }
 
 void readMulti(uint8_t reg, uint8_t* dst, uint8_t count) {
-    HAL_I2C_Mem_Read(&hi2c1, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, TIMEOUT);
+    HAL_I2C_Mem_Read(&VL53L0X_I2C_HANDLER, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, VL53L0X_I2C_TIMEOUT);
 }
 
-// Get reference SPAD (single photon avalanche diode) count and type
-// based on VL53L0X_get_info_from_device(),
-// but only gets reference SPAD count and type
 uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture) {
     uint8_t temp;
 
@@ -393,7 +718,7 @@ uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture) {
 
     writeReg(0x81, 0x00);
     writeReg(0xFF, 0x06);
-    writeReg(0x83, readReg( 0x83  & ~0x04));
+    writeReg(0x83, readReg(0x83 & ~0x04));
     writeReg(0xFF, 0x01);
     writeReg(0x00, 0x01);
 
@@ -403,13 +728,6 @@ uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture) {
     return 1;
 }
 
-// Set the VCSEL (vertical cavity surface emitting laser) pulse period for the
-// given period type (pre-range or final range) to the given value in PCLKs.
-// Longer periods seem to increase the potential range of the sensor.
-// Valid values are (even numbers only):
-//  pre:  12 to 18 (initialized default: 14)
-//  final: 8 to 14 (initialized default: 10)
-// based on VL53L0X_set_vcsel_pulse_period()
 uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
     uint8_t vcsel_period_reg = encodeVcselPeriod(period_pclks);
 
@@ -430,7 +748,6 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
     //
     // For the MSRC timeout, the same applies - this timeout being
     // dependant on the pre-range vcsel period."
-
 
     if (type == VcselPeriodPreRange) {
         // "Set phase check limits"
@@ -465,8 +782,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         // set_sequence_step_timeout() begin
         // (SequenceStepId == VL53L0X_SEQUENCESTEP_PRE_RANGE)
 
-        uint16_t new_pre_range_timeout_mclks =
-            timeoutMicrosecondsToMclks(timeouts.pre_range_us, period_pclks);
+        uint16_t new_pre_range_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.pre_range_us, period_pclks);
 
         writeReg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(new_pre_range_timeout_mclks));
 
@@ -475,8 +791,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         // set_sequence_step_timeout() begin
         // (SequenceStepId == VL53L0X_SEQUENCESTEP_MSRC)
 
-        uint16_t new_msrc_timeout_mclks =
-            timeoutMicrosecondsToMclks(timeouts.msrc_dss_tcc_us, period_pclks);
+        uint16_t new_msrc_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.msrc_dss_tcc_us, period_pclks);
 
         writeReg(MSRC_CONFIG_TIMEOUT_MACROP, (new_msrc_timeout_mclks > 256) ? 255 : (new_msrc_timeout_mclks - 1));
 
@@ -485,7 +800,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         switch (period_pclks) {
             case 8:
                 writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x10);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW,  0x08);
+                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
                 writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x02);
                 writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x0C);
                 writeReg(0xFF, 0x01);
@@ -495,7 +810,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
 
             case 10:
                 writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x28);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW,  0x08);
+                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
                 writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
                 writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x09);
                 writeReg(0xFF, 0x01);
@@ -505,7 +820,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
 
             case 12:
                 writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x38);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW,  0x08);
+                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
                 writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
                 writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x08);
                 writeReg(0xFF, 0x01);
@@ -515,7 +830,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
 
             case 14:
                 writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x48);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW,  0x08);
+                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
                 writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
                 writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x07);
                 writeReg(0xFF, 0x01);
@@ -541,14 +856,12 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         //  timeouts must be expressed in macro periods MClks
         //  because they have different vcsel periods."
 
-        uint16_t new_final_range_timeout_mclks =
-        timeoutMicrosecondsToMclks(timeouts.final_range_us, period_pclks);
+        uint16_t new_final_range_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.final_range_us, period_pclks);
 
         if (enables.pre_range)
             new_final_range_timeout_mclks += timeouts.pre_range_mclks;
 
-        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI,
-        encodeTimeout(new_final_range_timeout_mclks));
+        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(new_final_range_timeout_mclks));
 
         // set_sequence_step_timeout end
     } else {
@@ -560,8 +873,8 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
 
     setMeasurementTimingBudget(measurement_timing_budget_us);
 
-    // "Perform the phase calibration. This is needed after changing on vcsel period."
-    // VL53L0X_perform_phase_calibration() begin
+    // "Perform the phase calibration. This is needed after changing on vcsel
+    // period." VL53L0X_perform_phase_calibration() begin
 
     uint8_t sequence_config = readReg(SYSTEM_SEQUENCE_CONFIG);
     writeReg(SYSTEM_SEQUENCE_CONFIG, 0x02);
@@ -573,8 +886,6 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
     return 1;
 }
 
-// Get the VCSEL pulse period in PCLKs for the given period type.
-// based on VL53L0X_get_vcsel_pulse_period()
 uint8_t getVcselPulsePeriod(vcselPeriodType type) {
     if (type == VcselPeriodPreRange)
         return decodeVcselPeriod(readReg(PRE_RANGE_CONFIG_VCSEL_PERIOD));
@@ -584,23 +895,16 @@ uint8_t getVcselPulsePeriod(vcselPeriodType type) {
         return 255;
 }
 
-// Set the measurement timing budget in microseconds, which is the time allowed
-// for one measurement; the ST API and this library take care of splitting the
-// timing budget among the sub-steps in the ranging sequence. A longer timing
-// budget allows for more accurate measurements. Increasing the budget by a
-// factor of N decreases the range measurement standard deviation by a factor of
-// sqrt(N). Defaults to about 33 milliseconds; the minimum is 20 ms.
-// based on VL53L0X_set_measurement_timing_budget_micro_seconds()
 uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
     SequenceStepEnables enables;
     SequenceStepTimeouts timeouts;
 
-    const uint16_t StartOverhead      = 1320; // note that this is different than the value in get_
-    const uint16_t EndOverhead        = 960;
-    const uint16_t MsrcOverhead       = 660;
-    const uint16_t TccOverhead        = 590;
-    const uint16_t DssOverhead        = 690;
-    const uint16_t PreRangeOverhead   = 660;
+    const uint16_t StartOverhead = 1320;  // note that this is different than the value in get_
+    const uint16_t EndOverhead = 960;
+    const uint16_t MsrcOverhead = 660;
+    const uint16_t TccOverhead = 590;
+    const uint16_t DssOverhead = 690;
+    const uint16_t PreRangeOverhead = 660;
     const uint16_t FinalRangeOverhead = 550;
 
     const uint32_t MinTimingBudget = 20000;
@@ -649,40 +953,37 @@ uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
         //  because they have different vcsel periods."
 
         uint16_t final_range_timeout_mclks =
-        timeoutMicrosecondsToMclks(final_range_timeout_us, timeouts.final_range_vcsel_period_pclks);
+            timeoutMicrosecondsToMclks(final_range_timeout_us, timeouts.final_range_vcsel_period_pclks);
 
         if (enables.pre_range)
             final_range_timeout_mclks += timeouts.pre_range_mclks;
 
-        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI,
-        encodeTimeout(final_range_timeout_mclks));
+        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(final_range_timeout_mclks));
 
         // set_sequence_step_timeout() end
 
-        measurement_timing_budget_us = budget_us; // store for internal reuse
+        measurement_timing_budget_us = budget_us;  // store for internal reuse
     }
     return 1;
 }
-// Get the measurement timing budget in microseconds
-// based on VL53L0X_get_measurement_timing_budget_micro_seconds()
-// in us
+
 uint32_t getMeasurementTimingBudget() {
     SequenceStepEnables enables;
     SequenceStepTimeouts timeouts;
 
-    const uint16_t StartOverhead      = 1910;
-    const uint16_t EndOverhead        = 960;
-    const uint16_t MsrcOverhead       = 660;
-    const uint16_t TccOverhead        = 590;
-    const uint16_t DssOverhead        = 690;
-    const uint16_t PreRangeOverhead   = 660;
+    const uint16_t StartOverhead = 1910;
+    const uint16_t EndOverhead = 960;
+    const uint16_t MsrcOverhead = 660;
+    const uint16_t TccOverhead = 590;
+    const uint16_t DssOverhead = 690;
+    const uint16_t PreRangeOverhead = 660;
     const uint16_t FinalRangeOverhead = 550;
 
     // "Start and end overhead times always present"
     uint32_t budget_us = StartOverhead + EndOverhead;
 
     getSequenceStepEnables(&enables);
-      getSequenceStepTimeouts(&enables, &timeouts);
+    getSequenceStepTimeouts(&enables, &timeouts);
 
     if (enables.tcc)
         budget_us += (timeouts.msrc_dss_tcc_us + TccOverhead);
@@ -698,41 +999,30 @@ uint32_t getMeasurementTimingBudget() {
     if (enables.final_range)
         budget_us += (timeouts.final_range_us + FinalRangeOverhead);
 
-    measurement_timing_budget_us = budget_us; // store for internal reuse
+    measurement_timing_budget_us = budget_us;  // store for internal reuse
     return budget_us;
 }
 
-// Get sequence step enables
-// based on VL53L0X_GetSequenceStepEnables()
 void getSequenceStepEnables(SequenceStepEnables* enables) {
-  uint8_t sequence_config = readReg(SYSTEM_SEQUENCE_CONFIG);
+    uint8_t sequence_config = readReg(SYSTEM_SEQUENCE_CONFIG);
 
-  enables->tcc          = (sequence_config >> 4) & 0x1;
-  enables->dss          = (sequence_config >> 3) & 0x1;
-  enables->msrc         = (sequence_config >> 2) & 0x1;
-  enables->pre_range    = (sequence_config >> 6) & 0x1;
-  enables->final_range  = (sequence_config >> 7) & 0x1;
+    enables->tcc = (sequence_config >> 4) & 0x1;
+    enables->dss = (sequence_config >> 3) & 0x1;
+    enables->msrc = (sequence_config >> 2) & 0x1;
+    enables->pre_range = (sequence_config >> 6) & 0x1;
+    enables->final_range = (sequence_config >> 7) & 0x1;
 }
 
-// Get sequence step timeouts
-// based on get_sequence_step_timeout(),
-// but gets all timeouts instead of just the requested one, and also stores
-// intermediate values
 void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts) {
-    timeouts->pre_range_vcsel_period_pclks =
-        getVcselPulsePeriod(VcselPeriodPreRange);
-    timeouts->msrc_dss_tcc_mclks =
-        readReg(MSRC_CONFIG_TIMEOUT_MACROP) + 1;
+    timeouts->pre_range_vcsel_period_pclks = getVcselPulsePeriod(VcselPeriodPreRange);
+    timeouts->msrc_dss_tcc_mclks = readReg(MSRC_CONFIG_TIMEOUT_MACROP) + 1;
     timeouts->msrc_dss_tcc_us =
         timeoutMclksToMicroseconds(timeouts->msrc_dss_tcc_mclks, timeouts->pre_range_vcsel_period_pclks);
-    timeouts->pre_range_mclks =
-        decodeTimeout(readReg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI));
+    timeouts->pre_range_mclks = decodeTimeout(readReg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI));
     timeouts->pre_range_us =
         timeoutMclksToMicroseconds(timeouts->pre_range_mclks, timeouts->pre_range_vcsel_period_pclks);
-    timeouts->final_range_vcsel_period_pclks =
-        getVcselPulsePeriod(VcselPeriodFinalRange);
-    timeouts->final_range_mclks =
-        decodeTimeout(readReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI));
+    timeouts->final_range_vcsel_period_pclks = getVcselPulsePeriod(VcselPeriodFinalRange);
+    timeouts->final_range_mclks = decodeTimeout(readReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI));
 
     if (enables->pre_range)
         timeouts->final_range_mclks -= timeouts->pre_range_mclks;
@@ -741,19 +1031,11 @@ void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts*
         timeoutMclksToMicroseconds(timeouts->final_range_mclks, timeouts->final_range_vcsel_period_pclks);
 }
 
-// Decode sequence step timeout in MCLKs from register value
-// based on VL53L0X_decode_timeout()
-// Note: the original function returned a uint32_t, but the return value is
-// always stored in a uint16_t.
 uint16_t decodeTimeout(uint16_t reg_val) {
-  // format: "(LSByte * 2^MSByte) + 1"
-  return (uint16_t)((reg_val & 0x00FF) << (uint16_t)((reg_val & 0xFF00) >> 8)) + 1;
+    // format: "(LSByte * 2^MSByte) + 1"
+    return (uint16_t)((reg_val & 0x00FF) << (uint16_t)((reg_val & 0xFF00) >> 8)) + 1;
 }
 
-// Encode sequence step timeout register value from timeout in MCLKs
-// based on VL53L0X_encode_timeout()
-// Note: the original function took a uint16_t, but the argument passed to it
-// is always a uint16_t.
 uint16_t encodeTimeout(uint16_t timeout_mclks) {
     // format: "(LSByte * 2^MSByte) + 1"
     uint32_t ls_byte = 0;
@@ -772,25 +1054,21 @@ uint16_t encodeTimeout(uint16_t timeout_mclks) {
     }
 }
 
-// Convert sequence step timeout from MCLKs to microseconds with given VCSEL period in PCLKs
-// based on VL53L0X_calc_timeout_us()
 uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks) {
     uint32_t macro_period_ns = calcMacroPeriod(vcsel_period_pclks);
 
     return ((timeout_period_mclks * macro_period_ns) + (macro_period_ns / 2)) / 1000;
 }
 
-// Convert sequence step timeout from microseconds to MCLKs with given VCSEL period in PCLKs
-// based on VL53L0X_calc_timeout_mclks()
 uint32_t timeoutMicrosecondsToMclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks) {
     uint32_t macro_period_ns = calcMacroPeriod(vcsel_period_pclks);
 
     return (((timeout_period_us * 1000) + (macro_period_ns / 2)) / macro_period_ns);
 }
 
-// based on VL53L0X_perform_single_ref_calibration()
 uint8_t performSingleRefCalibration(uint8_t vhv_init_byte) {
-    writeReg(SYSRANGE_START, 0x01 | vhv_init_byte); // VL53L0X_REG_SYSRANGE_MODE_START_STOP
+    writeReg(SYSRANGE_START,
+             0x01 | vhv_init_byte);  // VL53L0X_REG_SYSRANGE_MODE_START_STOP
 
     startTimeout();
     while ((readReg(RESULT_INTERRUPT_STATUS) & 0x07) == 0)
@@ -801,84 +1079,4 @@ uint8_t performSingleRefCalibration(uint8_t vhv_init_byte) {
     writeReg(SYSRANGE_START, 0x00);
 
     return 1;
-}
-
-void vl53l0x_startContinuous(uint32_t period_ms) {
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, stop_variable);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
-
-    if (period_ms != 0) {
-        // continuous timed mode
-        // VL53L0X_SetInterMeasurementPeriodMilliSeconds() begin
-        uint16_t osc_calibrate_val = readReg16(OSC_CALIBRATE_VAL);
-        if (osc_calibrate_val != 0)
-            period_ms *= osc_calibrate_val;
-
-        writeReg32(SYSTEM_INTERMEASUREMENT_PERIOD, period_ms);
-        // VL53L0X_SetInterMeasurementPeriodMilliSeconds() end
-
-        writeReg(SYSRANGE_START, 0x04); // VL53L0X_REG_SYSRANGE_MODE_TIMED
-    } else {
-        // continuous back-to-back mode
-        writeReg(SYSRANGE_START, 0x02); // VL53L0X_REG_SYSRANGE_MODE_BACKTOBACK
-    }
-}
-
-// Stop continuous measurements
-// based on VL53L0X_StopMeasurement()
-void vl53l0x_stopContinuous() {
-    writeReg(SYSRANGE_START, 0x01); // VL53L0X_REG_SYSRANGE_MODE_SINGLESHOT
-
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, 0x00);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-}
-
-// Returns a range reading in millimeters when continuous mode is active
-uint16_t vl53l0x_getRange() {
-    startTimeout();
-    while ((readReg(RESULT_INTERRUPT_STATUS) & 0x07) == 0) {
-        if (checkTimeoutExpired()) {
-            did_timeout = 1;
-            return 65535;
-        }
-    }
-
-    // assumptions: Linearity Corrective Gain is 1000 (default);
-    // fractional ranging is not enabled
-    uint16_t range = readReg16(RESULT_RANGE_STATUS + 10);
-
-    writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
-
-    return range;
-}
-
-uint16_t vl53l0x_getRangeSingle() {
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, stop_variable);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
-
-    writeReg(SYSRANGE_START, 0x01);
-
-    // "Wait until start bit has been cleared"
-    startTimeout();
-    while (readReg(SYSRANGE_START) & 0x01) {
-        if (checkTimeoutExpired()) {
-            did_timeout = 1;
-            return 65535;
-        }
-    }
-
-    return vl53l0x_getRange();
 }

--- a/VL53L0X/vl53l0x.h
+++ b/VL53L0X/vl53l0x.h
@@ -1,115 +1,88 @@
 /**
- * Arquivo: vl53l0x.h
+ * @file vl53l0x.h
  *
- * Autor: Daniel Nery Silva de Oliveira
+ * @author Daniel Nery <daniel.nery@thunderatz.org>
  *
  * Equipe ThundeRatz de Robotica
- * 03/2017
+ *
+ * @date 03/2017
+ *
+ * @see https://github.com/pololu/vl53l0x-arduino
  */
-
-//! Ver: https://github.com/pololu/vl53l0x-arduino
 
 #ifndef _VL53L0X_H_
 #define _VL53L0X_H_
 
 // SPECIFIC INCLUDES HERE
 
-#define ADDRESS_DEFAULT (0x52)
+/*****************************************
+ * Public Constants
+ *****************************************/
 
-typedef enum {
-    SYSRANGE_START                              = 0x00,
+#define VL53L0X_DEFAULT_ADDRESS (0x52)       /**< Default sensor address, don't change */
+#define VL53L0X_TIMEOUT_RETURN_VALUE (65535) /**< Value returned if getRange times out */
 
-    SYSTEM_THRESH_HIGH                          = 0x0C,
-    SYSTEM_THRESH_LOW                           = 0x0E,
+#define VL53L0X_I2C_HANDLER hi2c1 /**< I2C handler */
 
-    SYSTEM_SEQUENCE_CONFIG                      = 0x01,
-    SYSTEM_RANGE_CONFIG                         = 0x09,
-    SYSTEM_INTERMEASUREMENT_PERIOD              = 0x04,
+//! @see setVcselPulsePeriod
+#define VL53L0X_VCSEL_PRE_RANGE 18
+#define VL53L0X_VCSEL_FINAL_RANGE 14
 
-    SYSTEM_INTERRUPT_CONFIG_GPIO                = 0x0A,
+/*****************************************
+ * Public Types
+ *****************************************/
 
-    GPIO_HV_MUX_ACTIVE_HIGH                     = 0x84,
+/*****************************************
+ * Public Function Prototypes
+ *****************************************/
 
-    SYSTEM_INTERRUPT_CLEAR                      = 0x0B,
-
-    RESULT_INTERRUPT_STATUS                     = 0x13,
-    RESULT_RANGE_STATUS                         = 0x14,
-
-    RESULT_CORE_AMBIENT_WINDOW_EVENTS_RTN       = 0xBC,
-    RESULT_CORE_RANGING_TOTAL_EVENTS_RTN        = 0xC0,
-    RESULT_CORE_AMBIENT_WINDOW_EVENTS_REF       = 0xD0,
-    RESULT_CORE_RANGING_TOTAL_EVENTS_REF        = 0xD4,
-    RESULT_PEAK_SIGNAL_RATE_REF                 = 0xB6,
-
-    ALGO_PART_TO_PART_RANGE_OFFSET_MM           = 0x28,
-
-    I2C_SLAVE_DEVICE_ADDRESS                    = 0x8A,
-
-    MSRC_CONFIG_CONTROL                         = 0x60,
-
-    PRE_RANGE_CONFIG_MIN_SNR                    = 0x27,
-    PRE_RANGE_CONFIG_VALID_PHASE_LOW            = 0x56,
-    PRE_RANGE_CONFIG_VALID_PHASE_HIGH           = 0x57,
-    PRE_RANGE_MIN_COUNT_RATE_RTN_LIMIT          = 0x64,
-
-    FINAL_RANGE_CONFIG_MIN_SNR                  = 0x67,
-    FINAL_RANGE_CONFIG_VALID_PHASE_LOW          = 0x47,
-    FINAL_RANGE_CONFIG_VALID_PHASE_HIGH         = 0x48,
-    FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT = 0x44,
-
-    PRE_RANGE_CONFIG_SIGMA_THRESH_HI            = 0x61,
-    PRE_RANGE_CONFIG_SIGMA_THRESH_LO            = 0x62,
-
-    PRE_RANGE_CONFIG_VCSEL_PERIOD               = 0x50,
-    PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI          = 0x51,
-    PRE_RANGE_CONFIG_TIMEOUT_MACROP_LO          = 0x52,
-
-    SYSTEM_HISTOGRAM_BIN                        = 0x81,
-    HISTOGRAM_CONFIG_INITIAL_PHASE_SELECT       = 0x33,
-    HISTOGRAM_CONFIG_READOUT_CTRL               = 0x55,
-
-    FINAL_RANGE_CONFIG_VCSEL_PERIOD             = 0x70,
-    FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI        = 0x71,
-    FINAL_RANGE_CONFIG_TIMEOUT_MACROP_LO        = 0x72,
-    CROSSTALK_COMPENSATION_PEAK_RATE_MCPS       = 0x20,
-
-    MSRC_CONFIG_TIMEOUT_MACROP                  = 0x46,
-
-    SOFT_RESET_GO2_SOFT_RESET_N                 = 0xBF,
-    IDENTIFICATION_MODEL_ID                     = 0xC0,
-    IDENTIFICATION_REVISION_ID                  = 0xC2,
-
-    OSC_CALIBRATE_VAL                           = 0xF8,
-
-    GLOBAL_CONFIG_VCSEL_WIDTH                   = 0x32,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_0            = 0xB0,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_1            = 0xB1,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_2            = 0xB2,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_3            = 0xB3,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_4            = 0xB4,
-    GLOBAL_CONFIG_SPAD_ENABLES_REF_5            = 0xB5,
-
-    GLOBAL_CONFIG_REF_EN_START_SELECT           = 0xB6,
-    DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD         = 0x4E,
-    DYNAMIC_SPAD_REF_EN_START_OFFSET            = 0x4F,
-    POWER_MANAGEMENT_GO1_POWER_FORCE            = 0x80,
-
-    VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV           = 0x89,
-
-    ALGO_PHASECAL_LIM                           = 0x30,
-    ALGO_PHASECAL_CONFIG_TIMEOUT                = 0x30,
-} vl53l0x_regAddr;
-
-typedef enum {
-    VcselPeriodPreRange,
-    VcselPeriodFinalRange
-} vcselPeriodType;
-
+/**
+ * @brief Initializes a single VL53L0X device.
+ *
+ * @note This must be called before any other function,
+ *       be sure only one uninitialized sensor is active
+ *       through XSHUT pin.
+ *
+ * @return 0 on failure, 1 on success.
+ */
 uint8_t vl53l0x_init();
+
+/**
+ * @brief Changes current device address.
+ *
+ * @param new_addr 8 bit address to be set
+ */
 void vl53l0x_setDevAddress(uint8_t new_addr);
+
+/**
+ * @brief Change the current working address.
+ *
+ * @note Subsequent functions will be applied to the sensor
+ *       with the address selected here.
+ *
+ * @param new_addr 8 bit address to be set
+ */
 void vl53l0x_setCurrentAddress(uint8_t new_addr);
+
+/**
+ * @brief Start current device continuous measuring.
+ *
+ * @param period_ms Measuring period
+ */
 void vl53l0x_startContinuous(uint32_t period_ms);
+
+/**
+ * @brief Stop current device continuous measuring.
+ */
 void vl53l0x_stopContinuous();
+
+/**
+ * @brief Get the current device's last measured range.
+ *
+ * @note vl53l0x_startContinuous must be called first.
+ *
+ * @return Range in millimeters or 65535 on failure.
+ */
 uint16_t vl53l0x_getRange();
 
 #endif

--- a/VL53L0X/vl53l0x.h
+++ b/VL53L0X/vl53l0x.h
@@ -10,8 +10,8 @@
  * @see https://github.com/pololu/vl53l0x-arduino
  */
 
-#ifndef _VL53L0X_H_
-#define _VL53L0X_H_
+#ifndef __VL53L0X_H__
+#define __VL53L0X_H__
 
 // SPECIFIC INCLUDES HERE
 
@@ -27,10 +27,6 @@
 //! @see setVcselPulsePeriod
 #define VL53L0X_VCSEL_PRE_RANGE 18
 #define VL53L0X_VCSEL_FINAL_RANGE 14
-
-/*****************************************
- * Public Types
- *****************************************/
 
 /*****************************************
  * Public Function Prototypes
@@ -85,4 +81,4 @@ void vl53l0x_stopContinuous();
  */
 uint16_t vl53l0x_getRange();
 
-#endif
+#endif  // __VL53L0X_H__


### PR DESCRIPTION
- Change ADDRESS_DEFAULT to VL53L0X_DEFAULT_ADDRESS to avoid name collisions
- Improved in-file documentation
- Add VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE, VL53L0X_VCSEL_FINAL_RANGE
  constants for easier changing
- Add VL53L0X_TIMEOUT_RETURN_VALUE