### PR TITLE
Adapt for submodule use

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+﻿---
+BasedOnStyle: Chromium
+AccessModifierOffset: '0'
+IndentWidth: '4'
+TabWidth: '4'
+UseTab: Never
+SpaceAfterCStyleCast: 'true'
+ColumnLimit: '120'
+...

--- a/LSM6DS3/lsm6ds3.c
+++ b/LSM6DS3/lsm6ds3.c
@@ -1,70 +1,94 @@
 /**
- * Arquivo: lsm6ds3.c
+ * @file lsm6ds3.c
  *
- * Autor: Daniel Nery Silva de Oliveira
+ * @author Daniel Nery <daniel.nery@thunderatz.org>
  *
  * Equipe ThundeRatz de Robotica
- * 10/2017
+ *
+ * @date 10/2017
+ *
+ * @see https://github.com/sparkfun/SparkFun_LSM6DS3_Arduino_Library
  */
-
-//! Ver: https://github.com/sparkfun/SparkFun_LSM6DS3_Arduino_Library
 
 #include "lsm6ds3.h"
 
+/*****************************************
+ * Private Constants
+ *****************************************/
+
 #define TIMEOUT 1000
 
-// Public variables
+/*****************************************
+ * Public Variables
+ *****************************************/
+
 sensor_settings_t lsm6ds3_settings;
 
-// Private variables
-static uint8_t address = DEFAULT_ADDRESS;
+/*****************************************
+ * Private Variables
+ *****************************************/
+
+static uint8_t address = LSM6DS3_DEFAULT_ADDRESS;
 static HAL_StatusTypeDef status;
+static I2C_HandleTypeDef* i2c_handler;
 
-// Private functions
-static void writeReg(uint8_t reg, uint8_t val);
-static void writeReg16(uint8_t reg, uint16_t val);
-static void writeReg32(uint8_t reg, uint32_t val);
-static void writeMulti(uint8_t reg, uint8_t* src, uint8_t count);
+/*****************************************
+ * Private Function Prototypes
+ *****************************************/
 
-static uint8_t readReg(uint8_t reg);
-static uint16_t readReg16(uint8_t reg);
-static uint32_t readReg32(uint8_t reg);
-static void readMulti(uint8_t reg, uint8_t* dst, uint8_t count);
+/**
+ * @brief HAL I2C wrapper functions.
+ */
+static void write_reg(uint8_t reg, uint8_t val);
+static void write_reg16(uint8_t reg, uint16_t val);
+static void write_reg32(uint8_t reg, uint32_t val);
+static void write_multi(uint8_t reg, uint8_t* src, uint8_t count);
+static uint8_t read_reg(uint8_t reg);
+static uint16_t read_reg16(uint8_t reg);
+static uint32_t read_reg32(uint8_t reg);
+static void read_multi(uint8_t reg, uint8_t* dst, uint8_t count);
 
-// Public functions
+/*****************************************
+ * Public Function Body Definitions
+ *****************************************/
+
+void lsm5ds3_i2c_set(I2C_HandleTypeDef* hi2c) {
+    i2c_handler = hi2c;
+}
+
 status_t lsm6ds3_init() {
     status_t returnStatus = IMU_SUCCESS;
 
     // Check ready
     HAL_Delay(10);
 
-    if(readReg(LSM6DS3_ACC_GYRO_WHO_AM_I_REG) != 0x69)
+    if (read_reg(LSM6DS3_ACC_GYRO_WHO_AM_I_REG) != 0x69) {
         returnStatus = IMU_HW_ERROR;
+    }
 
     // Settings
-    lsm6ds3_settings.gyroEnabled         = 1;
-    lsm6ds3_settings.gyroRange           = 2000;
-    lsm6ds3_settings.gyroSampleRate      = 416;
-    lsm6ds3_settings.gyroBandWidth       = 400;
-    lsm6ds3_settings.gyroFifoEnabled     = 1;
-    lsm6ds3_settings.gyroFifoDecimation  = 1;
+    lsm6ds3_settings.gyroEnabled = 1;
+    lsm6ds3_settings.gyroRange = 2000;
+    lsm6ds3_settings.gyroSampleRate = 416;
+    lsm6ds3_settings.gyroBandWidth = 400;
+    lsm6ds3_settings.gyroFifoEnabled = 1;
+    lsm6ds3_settings.gyroFifoDecimation = 1;
 
-    lsm6ds3_settings.accelEnabled        = 1;
-    lsm6ds3_settings.accelODROff         = 1;
-    lsm6ds3_settings.accelRange          = 16;
-    lsm6ds3_settings.accelSampleRate     = 416;
-    lsm6ds3_settings.accelBandWidth      = 100;
-    lsm6ds3_settings.accelFifoEnabled    = 1;
+    lsm6ds3_settings.accelEnabled = 1;
+    lsm6ds3_settings.accelODROff = 1;
+    lsm6ds3_settings.accelRange = 16;
+    lsm6ds3_settings.accelSampleRate = 416;
+    lsm6ds3_settings.accelBandWidth = 100;
+    lsm6ds3_settings.accelFifoEnabled = 1;
     lsm6ds3_settings.accelFifoDecimation = 1;
 
     lsm6ds3_settings.tempEnabled = 1;
 
     lsm6ds3_settings.commMode = 1;
 
-    lsm6ds3_settings.fifoThreshold  = 3000;
+    lsm6ds3_settings.fifoThreshold = 3000;
     lsm6ds3_settings.fifoSampleRate = 10;
-    lsm6ds3_settings.fifoModeWord   = 0;
-
+    lsm6ds3_settings.fifoModeWord = 0;
 
     uint8_t data_to_write = 0;
 
@@ -72,159 +96,193 @@ status_t lsm6ds3_init() {
     if (lsm6ds3_settings.accelEnabled) {
         switch (lsm6ds3_settings.accelBandWidth) {
             case 50:
-                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_50Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_50Hz;
+                break;
 
             case 100:
-                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_100Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_100Hz;
+                break;
 
             case 200:
-                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_200Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_200Hz;
+                break;
 
             case 400:
             default:
-                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_400Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_BW_XL_400Hz;
+                break;
         }
 
         switch (lsm6ds3_settings.accelRange) {
             case 2:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_2g; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_2g;
+                break;
 
             case 4:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_4g; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_4g;
+                break;
 
             case 8:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_8g; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_8g;
+                break;
 
             case 16:
             default:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_16g; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_XL_16g;
+                break;
         }
 
         switch (lsm6ds3_settings.accelSampleRate) {
             case 13:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_13Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_13Hz;
+                break;
 
             case 26:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_26Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_26Hz;
+                break;
 
             case 52:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_52Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_52Hz;
+                break;
 
             case 104:
             default:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_104Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_104Hz;
+                break;
 
             case 208:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_208Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_208Hz;
+                break;
 
             case 416:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_416Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_416Hz;
+                break;
 
             case 833:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_833Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_833Hz;
+                break;
 
             case 1660:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_1660Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_1660Hz;
+                break;
 
             case 3330:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_3330Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_3330Hz;
+                break;
 
             case 6660:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_6660Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_6660Hz;
+                break;
 
             case 13330:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_13330Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_XL_13330Hz;
+                break;
         }
     }
 
-    writeReg(LSM6DS3_ACC_GYRO_CTRL1_XL, data_to_write);
+    write_reg(LSM6DS3_ACC_GYRO_CTRL1_XL, data_to_write);
 
-    data_to_write = readReg(LSM6DS3_ACC_GYRO_CTRL4_C);
-    data_to_write &= ~((uint8_t)LSM6DS3_ACC_GYRO_BW_SCAL_ODR_ENABLED);
-    if (lsm6ds3_settings.accelODROff)
+    data_to_write = read_reg(LSM6DS3_ACC_GYRO_CTRL4_C);
+    data_to_write &= ~((uint8_t) LSM6DS3_ACC_GYRO_BW_SCAL_ODR_ENABLED);
+
+    if (lsm6ds3_settings.accelODROff) {
         data_to_write |= LSM6DS3_ACC_GYRO_BW_SCAL_ODR_ENABLED;
+    }
 
-    writeReg(LSM6DS3_ACC_GYRO_CTRL4_C, data_to_write);
+    write_reg(LSM6DS3_ACC_GYRO_CTRL4_C, data_to_write);
 
     // Setup gyro
     data_to_write = 0;
     if (lsm6ds3_settings.gyroEnabled) {
         switch (lsm6ds3_settings.gyroRange) {
             case 125:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_125_ENABLED; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_125_ENABLED;
+                break;
 
             case 245:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_245dps; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_245dps;
+                break;
 
             case 500:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_500dps; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_500dps;
+                break;
 
             case 1000:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_1000dps; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_1000dps;
+                break;
 
             case 2000:
             default:
-                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_2000dps; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_FS_G_2000dps;
+                break;
         }
 
         switch (lsm6ds3_settings.gyroSampleRate) {
             case 13:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_13Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_13Hz;
+                break;
 
             case 26:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_26Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_26Hz;
+                break;
 
             case 52:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_52Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_52Hz;
+                break;
 
             case 104:
             default:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_104Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_104Hz;
+                break;
 
             case 208:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_208Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_208Hz;
+                break;
 
             case 416:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_416Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_416Hz;
+                break;
 
             case 833:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_833Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_833Hz;
+                break;
 
             case 1660:
-                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_1660Hz; break;
+                data_to_write |= LSM6DS3_ACC_GYRO_ODR_G_1660Hz;
+                break;
         }
     }
 
-    writeReg(LSM6DS3_ACC_GYRO_CTRL2_G, data_to_write);
+    write_reg(LSM6DS3_ACC_GYRO_CTRL2_G, data_to_write);
 
     return returnStatus;
 }
 
 int16_t lsm6ds3_readRawAccelX() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTX_L_XL);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTX_L_XL);
 }
 
 int16_t lsm6ds3_readRawAccelY() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTY_L_XL);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTY_L_XL);
 }
 
 int16_t lsm6ds3_readRawAccelZ() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTZ_L_XL);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTZ_L_XL);
 }
 
 int16_t lsm6ds3_readRawGyroX() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTX_L_G);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTX_L_G);
 }
 
 int16_t lsm6ds3_readRawGyroY() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTY_L_G);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTY_L_G);
 }
 
 int16_t lsm6ds3_readRawGyroZ() {
-    return readReg16(LSM6DS3_ACC_GYRO_OUTZ_L_G);
+    return read_reg16(LSM6DS3_ACC_GYRO_OUTZ_L_G);
 }
 
-#define calcAccel(acc) ((float)(acc) * 0.061 * (lsm6ds3_settings.accelRange >> 1) / 1000.0)
+#define calcAccel(acc) ((float) (acc) *0.061 * (lsm6ds3_settings.accelRange >> 1) / 1000.0)
 
 float lsm6ds3_readFloatAccelX() {
     return calcAccel(lsm6ds3_readRawAccelX());
@@ -238,7 +296,8 @@ float lsm6ds3_readFloatAccelZ() {
     return calcAccel(lsm6ds3_readRawAccelZ());
 }
 
-#define calcGyro(gyr) ((float)(gyr) * 4.375 * (lsm6ds3_settings.gyroRange == 245 ? 2 : lsm6ds3_settings.gyroRange / 125) / 1000.0)
+#define calcGyro(gyr) \
+    ((float) (gyr) *4.375 * (lsm6ds3_settings.gyroRange == 245 ? 2 : lsm6ds3_settings.gyroRange / 125) / 1000.0)
 
 float lsm6ds3_readFloatGyroX() {
     return calcGyro(lsm6ds3_readRawGyroX());
@@ -253,75 +312,65 @@ float lsm6ds3_readFloatGyroZ() {
 }
 
 // Private functions
-void writeReg(uint8_t reg, uint8_t val) {
-    uint8_t bytes[2] = {
-        reg,
-        val
-    };
+void write_reg(uint8_t reg, uint8_t val) {
+    uint8_t bytes[2] = {reg, val};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 2, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 2, TIMEOUT) != HAL_OK)
+        ;
 }
 
-void writeReg16(uint8_t reg, uint16_t val) {
-    uint8_t bytes[3] = {
-        reg,
-        (val >> 8) & 0xFF,
-         val       & 0xFF
-    };
+void write_reg16(uint8_t reg, uint16_t val) {
+    uint8_t bytes[3] = {reg, (val >> 8) & 0xFF, val & 0xFF};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 3, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 3, TIMEOUT) != HAL_OK)
+        ;
 }
 
-void writeReg32(uint8_t reg, uint32_t val) {
-    uint8_t bytes[5] = {
-        reg,
-        (val >> 24) & 0xFF,
-        (val >> 16) & 0xFF,
-        (val >>  8) & 0xFF,
-         val        & 0xFF
-    };
+void write_reg32(uint8_t reg, uint32_t val) {
+    uint8_t bytes[5] = {reg, (val >> 24) & 0xFF, (val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF};
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), 5, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 5, TIMEOUT) != HAL_OK)
+        ;
 }
 
-void writeMulti(uint8_t reg, uint8_t* src, uint8_t count) {
+void write_multi(uint8_t reg, uint8_t* src, uint8_t count) {
     if (count > 31)
         return;
 
     count++;
-    uint8_t bytes[32] = { 0	};
+    uint8_t bytes[32] = {0};
     bytes[0] = reg;
     for (uint8_t i = 1; i < count; i++)
-        bytes[i] = src[i-1];
+        bytes[i] = src[i - 1];
 
-    while(HAL_I2C_Master_Transmit(&hi2c1, address, (uint8_t*)(&bytes), count, TIMEOUT) != HAL_OK);
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), count, TIMEOUT) != HAL_OK)
+        ;
 }
 
-uint8_t readReg(uint8_t reg) {
+uint8_t read_reg(uint8_t reg) {
     uint8_t val;
 
-    if((status = HAL_I2C_Mem_Read(&hi2c1, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1, TIMEOUT)) != HAL_OK)
+    if ((status = HAL_I2C_Mem_Read(i2c_handler, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1, TIMEOUT)) != HAL_OK) {
         return 0;
+    }
 
     return val;
 }
 
-uint16_t readReg16(uint8_t reg) {
+uint16_t read_reg16(uint8_t reg) {
     uint8_t val[2];
-    readMulti(reg, val, 2);
-    return (uint16_t)val[0] << 8 | val[1];
+    read_multi(reg, val, 2);
+
+    return (uint16_t) val[0] << 8 | val[1];
 }
 
-uint32_t readReg32(uint8_t reg) {
+uint32_t read_reg32(uint8_t reg) {
     uint8_t val[4];
-    readMulti(reg, val, 4);
+    read_multi(reg, val, 4);
 
-    return (uint32_t)val[0] << 24 |
-           (uint32_t)val[1] << 16 |
-           (uint16_t)val[2] <<  8 |
-                        val[3];
+    return (uint32_t) val[0] << 24 | (uint32_t) val[1] << 16 | (uint16_t) val[2] << 8 | val[3];
 }
 
-void readMulti(uint8_t reg, uint8_t* dst, uint8_t count) {
-    HAL_I2C_Mem_Read(&hi2c1, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, TIMEOUT);
+void read_multi(uint8_t reg, uint8_t* dst, uint8_t count) {
+    HAL_I2C_Mem_Read(i2c_handler, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, TIMEOUT);
 }

--- a/LSM6DS3/lsm6ds3.h
+++ b/LSM6DS3/lsm6ds3.h
@@ -1,20 +1,31 @@
 /**
- * Arquivo: lsm6ds3.h
+ * @file lsm6ds3.h
  *
- * Autor: Daniel Nery Silva de Oliveira
+ * @author Daniel Nery <daniel.nery@thunderatz.org>
  *
  * Equipe ThundeRatz de Robotica
- * 10/2017
+ *
+ * @date 10/2017
+ *
+ * @see https://github.com/sparkfun/SparkFun_LSM6DS3_Arduino_Library
  */
-
-//! Ver: https://github.com/sparkfun/SparkFun_LSM6DS3_Arduino_Library
 
 #ifndef _LSM6DS3_H_
 #define _LSM6DS3_H_
 
-// SPECIFIC INCLUDES HERE
+#include <stdint.h>
 
-#define DEFAULT_ADDRESS 0xD6
+#include "i2c.h"
+
+/*****************************************
+ * Public Constants
+ *****************************************/
+
+#define LSM6DS3_DEFAULT_ADDRESS 0xD6
+
+/*****************************************
+ * Public Types
+ *****************************************/
 
 // Return values
 typedef enum {
@@ -27,7 +38,7 @@ typedef enum {
 } status_t;
 
 typedef struct {
-    //Gyro settings
+    // Gyro settings
     uint8_t gyroEnabled;
     uint16_t gyroRange;
     uint16_t gyroSampleRate;
@@ -36,7 +47,7 @@ typedef struct {
     uint8_t gyroFifoEnabled;
     uint8_t gyroFifoDecimation;
 
-    //Accelerometer settings
+    // Accelerometer settings
     uint8_t accelEnabled;
     uint8_t accelODROff;
     uint16_t accelRange;
@@ -46,22 +57,29 @@ typedef struct {
     uint8_t accelFifoEnabled;
     uint8_t accelFifoDecimation;
 
-    //Temperature settings
+    // Temperature settings
     uint8_t tempEnabled;
 
-    //Non-basic mode settings
+    // Non-basic mode settings
     uint8_t commMode;
 
-    //FIFO control data
+    // FIFO control data
     uint16_t fifoThreshold;
     int16_t fifoSampleRate;
     uint8_t fifoModeWord;
 } sensor_settings_t;
 
-// Public variables
+/*****************************************
+ * Public Variables
+ *****************************************/
+
 extern sensor_settings_t lsm6ds3_settings;
 
-// Public function prototypes
+/*****************************************
+ * Public Function Prototypes
+ *****************************************/
+
+void lsm5ds3_i2c_set(I2C_HandleTypeDef* hi2c);
 status_t lsm6ds3_init();
 
 int16_t lsm6ds3_readRawAccelX();
@@ -79,1897 +97,1896 @@ float lsm6ds3_readFloatGyroY();
 float lsm6ds3_readFloatGyroZ();
 
 /************** Device Register  *******************/
-#define LSM6DS3_ACC_GYRO_TEST_PAGE  			0X00
-#define LSM6DS3_ACC_GYRO_RAM_ACCESS  			0X01
-#define LSM6DS3_ACC_GYRO_SENSOR_SYNC_TIME  		0X04
-#define LSM6DS3_ACC_GYRO_SENSOR_SYNC_EN  		0X05
-#define LSM6DS3_ACC_GYRO_FIFO_CTRL1  			0X06
-#define LSM6DS3_ACC_GYRO_FIFO_CTRL2  			0X07
-#define LSM6DS3_ACC_GYRO_FIFO_CTRL3  			0X08
-#define LSM6DS3_ACC_GYRO_FIFO_CTRL4  			0X09
-#define LSM6DS3_ACC_GYRO_FIFO_CTRL5  			0X0A
-#define LSM6DS3_ACC_GYRO_ORIENT_CFG_G  			0X0B
-#define LSM6DS3_ACC_GYRO_REFERENCE_G  			0X0C
-#define LSM6DS3_ACC_GYRO_INT1_CTRL  			0X0D
-#define LSM6DS3_ACC_GYRO_INT2_CTRL  			0X0E
-#define LSM6DS3_ACC_GYRO_WHO_AM_I_REG  			0X0F
-#define LSM6DS3_ACC_GYRO_CTRL1_XL				0X10
-#define LSM6DS3_ACC_GYRO_CTRL2_G				0X11
-#define LSM6DS3_ACC_GYRO_CTRL3_C				0X12
-#define LSM6DS3_ACC_GYRO_CTRL4_C				0X13
-#define LSM6DS3_ACC_GYRO_CTRL5_C				0X14
-#define LSM6DS3_ACC_GYRO_CTRL6_G				0X15
-#define LSM6DS3_ACC_GYRO_CTRL7_G				0X16
-#define LSM6DS3_ACC_GYRO_CTRL8_XL				0X17
-#define LSM6DS3_ACC_GYRO_CTRL9_XL				0X18
-#define LSM6DS3_ACC_GYRO_CTRL10_C				0X19
-#define LSM6DS3_ACC_GYRO_MASTER_CONFIG  		0X1A
-#define LSM6DS3_ACC_GYRO_WAKE_UP_SRC  			0X1B
-#define LSM6DS3_ACC_GYRO_TAP_SRC  				0X1C
-#define LSM6DS3_ACC_GYRO_D6D_SRC  				0X1D
-#define LSM6DS3_ACC_GYRO_STATUS_REG  			0X1E
-#define LSM6DS3_ACC_GYRO_OUT_TEMP_L  			0X20
-#define LSM6DS3_ACC_GYRO_OUT_TEMP_H  			0X21
-#define LSM6DS3_ACC_GYRO_OUTX_L_G  				0X22
-#define LSM6DS3_ACC_GYRO_OUTX_H_G  				0X23
-#define LSM6DS3_ACC_GYRO_OUTY_L_G  				0X24
-#define LSM6DS3_ACC_GYRO_OUTY_H_G  				0X25
-#define LSM6DS3_ACC_GYRO_OUTZ_L_G  				0X26
-#define LSM6DS3_ACC_GYRO_OUTZ_H_G  				0X27
-#define LSM6DS3_ACC_GYRO_OUTX_L_XL  			0X28
-#define LSM6DS3_ACC_GYRO_OUTX_H_XL  			0X29
-#define LSM6DS3_ACC_GYRO_OUTY_L_XL  			0X2A
-#define LSM6DS3_ACC_GYRO_OUTY_H_XL  			0X2B
-#define LSM6DS3_ACC_GYRO_OUTZ_L_XL  			0X2C
-#define LSM6DS3_ACC_GYRO_OUTZ_H_XL  			0X2D
-#define LSM6DS3_ACC_GYRO_SENSORHUB1_REG  		0X2E
-#define LSM6DS3_ACC_GYRO_SENSORHUB2_REG  		0X2F
-#define LSM6DS3_ACC_GYRO_SENSORHUB3_REG  		0X30
-#define LSM6DS3_ACC_GYRO_SENSORHUB4_REG  		0X31
-#define LSM6DS3_ACC_GYRO_SENSORHUB5_REG  		0X32
-#define LSM6DS3_ACC_GYRO_SENSORHUB6_REG  		0X33
-#define LSM6DS3_ACC_GYRO_SENSORHUB7_REG  		0X34
-#define LSM6DS3_ACC_GYRO_SENSORHUB8_REG  		0X35
-#define LSM6DS3_ACC_GYRO_SENSORHUB9_REG  		0X36
-#define LSM6DS3_ACC_GYRO_SENSORHUB10_REG  		0X37
-#define LSM6DS3_ACC_GYRO_SENSORHUB11_REG  		0X38
-#define LSM6DS3_ACC_GYRO_SENSORHUB12_REG  		0X39
-#define LSM6DS3_ACC_GYRO_FIFO_STATUS1  			0X3A
-#define LSM6DS3_ACC_GYRO_FIFO_STATUS2  			0X3B
-#define LSM6DS3_ACC_GYRO_FIFO_STATUS3  			0X3C
-#define LSM6DS3_ACC_GYRO_FIFO_STATUS4  			0X3D
-#define LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_L  		0X3E
-#define LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_H  		0X3F
-#define LSM6DS3_ACC_GYRO_TIMESTAMP0_REG  		0X40
-#define LSM6DS3_ACC_GYRO_TIMESTAMP1_REG  		0X41
-#define LSM6DS3_ACC_GYRO_TIMESTAMP2_REG  		0X42
-#define LSM6DS3_ACC_GYRO_STEP_COUNTER_L  		0X4B
-#define LSM6DS3_ACC_GYRO_STEP_COUNTER_H  		0X4C
-#define LSM6DS3_ACC_GYRO_FUNC_SRC  				0X53
-#define LSM6DS3_ACC_GYRO_TAP_CFG1  				0X58
-#define LSM6DS3_ACC_GYRO_TAP_THS_6D  			0X59
-#define LSM6DS3_ACC_GYRO_INT_DUR2  				0X5A
-#define LSM6DS3_ACC_GYRO_WAKE_UP_THS  			0X5B
-#define LSM6DS3_ACC_GYRO_WAKE_UP_DUR  			0X5C
-#define LSM6DS3_ACC_GYRO_FREE_FALL  			0X5D
-#define LSM6DS3_ACC_GYRO_MD1_CFG  				0X5E
-#define LSM6DS3_ACC_GYRO_MD2_CFG  				0X5F
+#define LSM6DS3_ACC_GYRO_TEST_PAGE 0X00
+#define LSM6DS3_ACC_GYRO_RAM_ACCESS 0X01
+#define LSM6DS3_ACC_GYRO_SENSOR_SYNC_TIME 0X04
+#define LSM6DS3_ACC_GYRO_SENSOR_SYNC_EN 0X05
+#define LSM6DS3_ACC_GYRO_FIFO_CTRL1 0X06
+#define LSM6DS3_ACC_GYRO_FIFO_CTRL2 0X07
+#define LSM6DS3_ACC_GYRO_FIFO_CTRL3 0X08
+#define LSM6DS3_ACC_GYRO_FIFO_CTRL4 0X09
+#define LSM6DS3_ACC_GYRO_FIFO_CTRL5 0X0A
+#define LSM6DS3_ACC_GYRO_ORIENT_CFG_G 0X0B
+#define LSM6DS3_ACC_GYRO_REFERENCE_G 0X0C
+#define LSM6DS3_ACC_GYRO_INT1_CTRL 0X0D
+#define LSM6DS3_ACC_GYRO_INT2_CTRL 0X0E
+#define LSM6DS3_ACC_GYRO_WHO_AM_I_REG 0X0F
+#define LSM6DS3_ACC_GYRO_CTRL1_XL 0X10
+#define LSM6DS3_ACC_GYRO_CTRL2_G 0X11
+#define LSM6DS3_ACC_GYRO_CTRL3_C 0X12
+#define LSM6DS3_ACC_GYRO_CTRL4_C 0X13
+#define LSM6DS3_ACC_GYRO_CTRL5_C 0X14
+#define LSM6DS3_ACC_GYRO_CTRL6_G 0X15
+#define LSM6DS3_ACC_GYRO_CTRL7_G 0X16
+#define LSM6DS3_ACC_GYRO_CTRL8_XL 0X17
+#define LSM6DS3_ACC_GYRO_CTRL9_XL 0X18
+#define LSM6DS3_ACC_GYRO_CTRL10_C 0X19
+#define LSM6DS3_ACC_GYRO_MASTER_CONFIG 0X1A
+#define LSM6DS3_ACC_GYRO_WAKE_UP_SRC 0X1B
+#define LSM6DS3_ACC_GYRO_TAP_SRC 0X1C
+#define LSM6DS3_ACC_GYRO_D6D_SRC 0X1D
+#define LSM6DS3_ACC_GYRO_STATUS_REG 0X1E
+#define LSM6DS3_ACC_GYRO_OUT_TEMP_L 0X20
+#define LSM6DS3_ACC_GYRO_OUT_TEMP_H 0X21
+#define LSM6DS3_ACC_GYRO_OUTX_L_G 0X22
+#define LSM6DS3_ACC_GYRO_OUTX_H_G 0X23
+#define LSM6DS3_ACC_GYRO_OUTY_L_G 0X24
+#define LSM6DS3_ACC_GYRO_OUTY_H_G 0X25
+#define LSM6DS3_ACC_GYRO_OUTZ_L_G 0X26
+#define LSM6DS3_ACC_GYRO_OUTZ_H_G 0X27
+#define LSM6DS3_ACC_GYRO_OUTX_L_XL 0X28
+#define LSM6DS3_ACC_GYRO_OUTX_H_XL 0X29
+#define LSM6DS3_ACC_GYRO_OUTY_L_XL 0X2A
+#define LSM6DS3_ACC_GYRO_OUTY_H_XL 0X2B
+#define LSM6DS3_ACC_GYRO_OUTZ_L_XL 0X2C
+#define LSM6DS3_ACC_GYRO_OUTZ_H_XL 0X2D
+#define LSM6DS3_ACC_GYRO_SENSORHUB1_REG 0X2E
+#define LSM6DS3_ACC_GYRO_SENSORHUB2_REG 0X2F
+#define LSM6DS3_ACC_GYRO_SENSORHUB3_REG 0X30
+#define LSM6DS3_ACC_GYRO_SENSORHUB4_REG 0X31
+#define LSM6DS3_ACC_GYRO_SENSORHUB5_REG 0X32
+#define LSM6DS3_ACC_GYRO_SENSORHUB6_REG 0X33
+#define LSM6DS3_ACC_GYRO_SENSORHUB7_REG 0X34
+#define LSM6DS3_ACC_GYRO_SENSORHUB8_REG 0X35
+#define LSM6DS3_ACC_GYRO_SENSORHUB9_REG 0X36
+#define LSM6DS3_ACC_GYRO_SENSORHUB10_REG 0X37
+#define LSM6DS3_ACC_GYRO_SENSORHUB11_REG 0X38
+#define LSM6DS3_ACC_GYRO_SENSORHUB12_REG 0X39
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS1 0X3A
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS2 0X3B
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS3 0X3C
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS4 0X3D
+#define LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_L 0X3E
+#define LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_H 0X3F
+#define LSM6DS3_ACC_GYRO_TIMESTAMP0_REG 0X40
+#define LSM6DS3_ACC_GYRO_TIMESTAMP1_REG 0X41
+#define LSM6DS3_ACC_GYRO_TIMESTAMP2_REG 0X42
+#define LSM6DS3_ACC_GYRO_STEP_COUNTER_L 0X4B
+#define LSM6DS3_ACC_GYRO_STEP_COUNTER_H 0X4C
+#define LSM6DS3_ACC_GYRO_FUNC_SRC 0X53
+#define LSM6DS3_ACC_GYRO_TAP_CFG1 0X58
+#define LSM6DS3_ACC_GYRO_TAP_THS_6D 0X59
+#define LSM6DS3_ACC_GYRO_INT_DUR2 0X5A
+#define LSM6DS3_ACC_GYRO_WAKE_UP_THS 0X5B
+#define LSM6DS3_ACC_GYRO_WAKE_UP_DUR 0X5C
+#define LSM6DS3_ACC_GYRO_FREE_FALL 0X5D
+#define LSM6DS3_ACC_GYRO_MD1_CFG 0X5E
+#define LSM6DS3_ACC_GYRO_MD2_CFG 0X5F
 
 /************** Access Device RAM  *******************/
-#define LSM6DS3_ACC_GYRO_ADDR0_TO_RW_RAM		0x62
-#define LSM6DS3_ACC_GYRO_ADDR1_TO_RW_RAM		0x63
-#define LSM6DS3_ACC_GYRO_DATA_TO_WR_RAM			0x64
-#define LSM6DS3_ACC_GYRO_DATA_RD_FROM_RAM		0x65
+#define LSM6DS3_ACC_GYRO_ADDR0_TO_RW_RAM 0x62
+#define LSM6DS3_ACC_GYRO_ADDR1_TO_RW_RAM 0x63
+#define LSM6DS3_ACC_GYRO_DATA_TO_WR_RAM 0x64
+#define LSM6DS3_ACC_GYRO_DATA_RD_FROM_RAM 0x65
 
-#define LSM6DS3_ACC_GYRO_RAM_SIZE				4096
+#define LSM6DS3_ACC_GYRO_RAM_SIZE 4096
 
 /************** Embedded functions register mapping  *******************/
-#define LSM6DS3_ACC_GYRO_SLV0_ADD                     0x02
-#define LSM6DS3_ACC_GYRO_SLV0_SUBADD                  0x03
-#define LSM6DS3_ACC_GYRO_SLAVE0_CONFIG                0x04
-#define LSM6DS3_ACC_GYRO_SLV1_ADD                     0x05
-#define LSM6DS3_ACC_GYRO_SLV1_SUBADD                  0x06
-#define LSM6DS3_ACC_GYRO_SLAVE1_CONFIG                0x07
-#define LSM6DS3_ACC_GYRO_SLV2_ADD                     0x08
-#define LSM6DS3_ACC_GYRO_SLV2_SUBADD                  0x09
-#define LSM6DS3_ACC_GYRO_SLAVE2_CONFIG                0x0A
-#define LSM6DS3_ACC_GYRO_SLV3_ADD                     0x0B
-#define LSM6DS3_ACC_GYRO_SLV3_SUBADD                  0x0C
-#define LSM6DS3_ACC_GYRO_SLAVE3_CONFIG                0x0D
-#define LSM6DS3_ACC_GYRO_DATAWRITE_SRC_MODE_SUB_SLV0  0x0E
-#define LSM6DS3_ACC_GYRO_CONFIG_PEDO_THS_MIN          0x0F
-#define LSM6DS3_ACC_GYRO_CONFIG_TILT_IIR              0x10
-#define LSM6DS3_ACC_GYRO_CONFIG_TILT_ACOS             0x11
-#define LSM6DS3_ACC_GYRO_CONFIG_TILT_WTIME            0x12
-#define LSM6DS3_ACC_GYRO_SM_STEP_THS                  0x13
-#define LSM6DS3_ACC_GYRO_MAG_SI_XX                    0x24
-#define LSM6DS3_ACC_GYRO_MAG_SI_XY                    0x25
-#define LSM6DS3_ACC_GYRO_MAG_SI_XZ                    0x26
-#define LSM6DS3_ACC_GYRO_MAG_SI_YX                    0x27
-#define LSM6DS3_ACC_GYRO_MAG_SI_YY                    0x28
-#define LSM6DS3_ACC_GYRO_MAG_SI_YZ                    0x29
-#define LSM6DS3_ACC_GYRO_MAG_SI_ZX                    0x2A
-#define LSM6DS3_ACC_GYRO_MAG_SI_ZY                    0x2B
-#define LSM6DS3_ACC_GYRO_MAG_SI_ZZ                    0x2C
-#define LSM6DS3_ACC_GYRO_MAG_OFFX_L                   0x2D
-#define LSM6DS3_ACC_GYRO_MAG_OFFX_H                   0x2E
-#define LSM6DS3_ACC_GYRO_MAG_OFFY_L                   0x2F
-#define LSM6DS3_ACC_GYRO_MAG_OFFY_H                   0x30
-#define LSM6DS3_ACC_GYRO_MAG_OFFZ_L                   0x31
-#define LSM6DS3_ACC_GYRO_MAG_OFFZ_H                   0x32
+#define LSM6DS3_ACC_GYRO_SLV0_ADD 0x02
+#define LSM6DS3_ACC_GYRO_SLV0_SUBADD 0x03
+#define LSM6DS3_ACC_GYRO_SLAVE0_CONFIG 0x04
+#define LSM6DS3_ACC_GYRO_SLV1_ADD 0x05
+#define LSM6DS3_ACC_GYRO_SLV1_SUBADD 0x06
+#define LSM6DS3_ACC_GYRO_SLAVE1_CONFIG 0x07
+#define LSM6DS3_ACC_GYRO_SLV2_ADD 0x08
+#define LSM6DS3_ACC_GYRO_SLV2_SUBADD 0x09
+#define LSM6DS3_ACC_GYRO_SLAVE2_CONFIG 0x0A
+#define LSM6DS3_ACC_GYRO_SLV3_ADD 0x0B
+#define LSM6DS3_ACC_GYRO_SLV3_SUBADD 0x0C
+#define LSM6DS3_ACC_GYRO_SLAVE3_CONFIG 0x0D
+#define LSM6DS3_ACC_GYRO_DATAWRITE_SRC_MODE_SUB_SLV0 0x0E
+#define LSM6DS3_ACC_GYRO_CONFIG_PEDO_THS_MIN 0x0F
+#define LSM6DS3_ACC_GYRO_CONFIG_TILT_IIR 0x10
+#define LSM6DS3_ACC_GYRO_CONFIG_TILT_ACOS 0x11
+#define LSM6DS3_ACC_GYRO_CONFIG_TILT_WTIME 0x12
+#define LSM6DS3_ACC_GYRO_SM_STEP_THS 0x13
+#define LSM6DS3_ACC_GYRO_MAG_SI_XX 0x24
+#define LSM6DS3_ACC_GYRO_MAG_SI_XY 0x25
+#define LSM6DS3_ACC_GYRO_MAG_SI_XZ 0x26
+#define LSM6DS3_ACC_GYRO_MAG_SI_YX 0x27
+#define LSM6DS3_ACC_GYRO_MAG_SI_YY 0x28
+#define LSM6DS3_ACC_GYRO_MAG_SI_YZ 0x29
+#define LSM6DS3_ACC_GYRO_MAG_SI_ZX 0x2A
+#define LSM6DS3_ACC_GYRO_MAG_SI_ZY 0x2B
+#define LSM6DS3_ACC_GYRO_MAG_SI_ZZ 0x2C
+#define LSM6DS3_ACC_GYRO_MAG_OFFX_L 0x2D
+#define LSM6DS3_ACC_GYRO_MAG_OFFX_H 0x2E
+#define LSM6DS3_ACC_GYRO_MAG_OFFY_L 0x2F
+#define LSM6DS3_ACC_GYRO_MAG_OFFY_H 0x30
+#define LSM6DS3_ACC_GYRO_MAG_OFFZ_L 0x31
+#define LSM6DS3_ACC_GYRO_MAG_OFFZ_H 0x32
 
 /*******************************************************************************
-* Register      : TEST_PAGE
-* Address       : 0X00
-* Bit Group Name: FLASH_PAGE
-* Permission    : RW
-*******************************************************************************/
-#define FLASH_PAGE    0x40
+ * Register      : TEST_PAGE
+ * Address       : 0X00
+ * Bit Group Name: FLASH_PAGE
+ * Permission    : RW
+ *******************************************************************************/
+#define FLASH_PAGE 0x40
 
 /*******************************************************************************
-* Register      : RAM_ACCESS
-* Address       : 0X01
-* Bit Group Name: PROG_RAM1
-* Permission    : RW
-*******************************************************************************/
+ * Register      : RAM_ACCESS
+ * Address       : 0X01
+ * Bit Group Name: PROG_RAM1
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PROG_RAM1_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PROG_RAM1_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_PROG_RAM1_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_PROG_RAM1_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_PROG_RAM1_t;
 
 /*******************************************************************************
-* Register      : RAM_ACCESS
-* Address       : 0X01
-* Bit Group Name: CUSTOMROM1
-* Permission    : RW
-*******************************************************************************/
+ * Register      : RAM_ACCESS
+ * Address       : 0X01
+ * Bit Group Name: CUSTOMROM1
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_CUSTOMROM1_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_CUSTOMROM1_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_CUSTOMROM1_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_CUSTOMROM1_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_CUSTOMROM1_t;
 
 /*******************************************************************************
-* Register      : RAM_ACCESS
-* Address       : 0X01
-* Bit Group Name: RAM_PAGE
-* Permission    : RW
-*******************************************************************************/
+ * Register      : RAM_ACCESS
+ * Address       : 0X01
+ * Bit Group Name: RAM_PAGE
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_RAM_PAGE_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_RAM_PAGE_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_RAM_PAGE_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_RAM_PAGE_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_RAM_PAGE_t;
 
 /*******************************************************************************
-* Register      : SENSOR_SYNC_TIME
-* Address       : 0X04
-* Bit Group Name: TPH
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_TPH_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_TPH_POSITION  	0
+ * Register      : SENSOR_SYNC_TIME
+ * Address       : 0X04
+ * Bit Group Name: TPH
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_TPH_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_TPH_POSITION 0
 
 /*******************************************************************************
-* Register      : SENSOR_SYNC_EN
-* Address       : 0X05
-* Bit Group Name: SYNC_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : SENSOR_SYNC_EN
+ * Address       : 0X05
+ * Bit Group Name: SYNC_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SYNC_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SYNC_EN_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_SYNC_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_SYNC_EN_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_SYNC_EN_t;
 
 /*******************************************************************************
-* Register      : SENSOR_SYNC_EN
-* Address       : 0X05
-* Bit Group Name: HP_RST
-* Permission    : RW
-*******************************************************************************/
+ * Register      : SENSOR_SYNC_EN
+ * Address       : 0X05
+ * Bit Group Name: HP_RST
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_HP_RST_RST_OFF 		 = 0x00,
-    LSM6DS3_ACC_GYRO_HP_RST_RST_ON 		 = 0x02,
+    LSM6DS3_ACC_GYRO_HP_RST_RST_OFF = 0x00,
+    LSM6DS3_ACC_GYRO_HP_RST_RST_ON = 0x02,
 } LSM6DS3_ACC_GYRO_HP_RST_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL1
-* Address       : 0X06
-* Bit Group Name: WTM_FIFO
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL1_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL1_POSITION  	0
-#define  	LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_MASK  	0x0F
-#define  	LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_POSITION  	0
+ * Register      : FIFO_CTRL1
+ * Address       : 0X06
+ * Bit Group Name: WTM_FIFO
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL1_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL1_POSITION 0
+#define LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_MASK 0x0F
+#define LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_POSITION 0
 
 /*******************************************************************************
-* Register      : FIFO_CTRL2
-* Address       : 0X07
-* Bit Group Name: TIM_PEDO_FIFO_DRDY
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL2
+ * Address       : 0X07
+ * Bit Group Name: TIM_PEDO_FIFO_DRDY
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL2
-* Address       : 0X07
-* Bit Group Name: TIM_PEDO_FIFO_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL2
+ * Address       : 0X07
+ * Bit Group Name: TIM_PEDO_FIFO_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL3
-* Address       : 0X08
-* Bit Group Name: DEC_FIFO_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL3
+ * Address       : 0X08
+ * Bit Group Name: DEC_FIFO_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DATA_NOT_IN_FIFO 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_NO_DECIMATION 		 = 0x01,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_2 		 = 0x02,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_3 		 = 0x03,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_4 		 = 0x04,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_8 		 = 0x05,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_16 		 = 0x06,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_32 		 = 0x07,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DATA_NOT_IN_FIFO = 0x00,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_NO_DECIMATION = 0x01,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_2 = 0x02,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_3 = 0x03,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_4 = 0x04,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_8 = 0x05,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_16 = 0x06,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_XL_DECIMATION_BY_32 = 0x07,
 } LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL3
-* Address       : 0X08
-* Bit Group Name: DEC_FIFO_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL3
+ * Address       : 0X08
+ * Bit Group Name: DEC_FIFO_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DATA_NOT_IN_FIFO 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_NO_DECIMATION 		 = 0x08,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_2 		 = 0x10,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_3 		 = 0x18,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_4 		 = 0x20,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_8 		 = 0x28,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_16 		 = 0x30,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_32 		 = 0x38,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DATA_NOT_IN_FIFO = 0x00,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_NO_DECIMATION = 0x08,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_2 = 0x10,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_3 = 0x18,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_4 = 0x20,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_8 = 0x28,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_16 = 0x30,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_G_DECIMATION_BY_32 = 0x38,
 } LSM6DS3_ACC_GYRO_DEC_FIFO_G_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL4
-* Address       : 0X09
-* Bit Group Name: DEC_FIFO_SLV0
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL4
+ * Address       : 0X09
+ * Bit Group Name: DEC_FIFO_SLV0
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DATA_NOT_IN_FIFO 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_NO_DECIMATION 		 = 0x01,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_2 		 = 0x02,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_3 		 = 0x03,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_4 		 = 0x04,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_8 		 = 0x05,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_16 		 = 0x06,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_32 		 = 0x07,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DATA_NOT_IN_FIFO = 0x00,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_NO_DECIMATION = 0x01,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_2 = 0x02,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_3 = 0x03,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_4 = 0x04,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_8 = 0x05,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_16 = 0x06,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_DECIMATION_BY_32 = 0x07,
 } LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL4
-* Address       : 0X09
-* Bit Group Name: DEC_FIFO_SLV1
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL4
+ * Address       : 0X09
+ * Bit Group Name: DEC_FIFO_SLV1
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DATA_NOT_IN_FIFO 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_NO_DECIMATION 		 = 0x08,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_2 		 = 0x10,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_3 		 = 0x18,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_4 		 = 0x20,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_8 		 = 0x28,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_16 		 = 0x30,
-    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_32 		 = 0x38,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DATA_NOT_IN_FIFO = 0x00,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_NO_DECIMATION = 0x08,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_2 = 0x10,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_3 = 0x18,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_4 = 0x20,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_8 = 0x28,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_16 = 0x30,
+    LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_DECIMATION_BY_32 = 0x38,
 } LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL4
-* Address       : 0X09
-* Bit Group Name: HI_DATA_ONLY
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL4
+ * Address       : 0X09
+ * Bit Group Name: HI_DATA_ONLY
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_HI_DATA_ONLY_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_HI_DATA_ONLY_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_HI_DATA_ONLY_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_HI_DATA_ONLY_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL5
-* Address       : 0X0A
-* Bit Group Name: FIFO_MODE
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL5
+ * Address       : 0X0A
+ * Bit Group Name: FIFO_MODE
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FIFO_MODE_BYPASS 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_FIFO 		 = 0x01,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_STREAM 		 = 0x02,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_STF 		 = 0x03,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_BTS 		 = 0x04,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_DYN_STREAM 		 = 0x05,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_DYN_STREAM_2 		 = 0x06,
-    LSM6DS3_ACC_GYRO_FIFO_MODE_BTF 		 = 0x07,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_BYPASS = 0x00,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_FIFO = 0x01,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_STREAM = 0x02,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_STF = 0x03,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_BTS = 0x04,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_DYN_STREAM = 0x05,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_DYN_STREAM_2 = 0x06,
+    LSM6DS3_ACC_GYRO_FIFO_MODE_BTF = 0x07,
 } LSM6DS3_ACC_GYRO_FIFO_MODE_t;
 
 /*******************************************************************************
-* Register      : FIFO_CTRL5
-* Address       : 0X0A
-* Bit Group Name: ODR_FIFO
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FIFO_CTRL5
+ * Address       : 0X0A
+ * Bit Group Name: ODR_FIFO
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ODR_FIFO_10Hz 		 = 0x08,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_25Hz 		 = 0x10,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_50Hz 		 = 0x18,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_100Hz 		 = 0x20,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_200Hz 		 = 0x28,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_400Hz 		 = 0x30,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_800Hz 		 = 0x38,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_1600Hz 		 = 0x40,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_3300Hz 		 = 0x48,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_6600Hz 		 = 0x50,
-    LSM6DS3_ACC_GYRO_ODR_FIFO_13300Hz 		 = 0x58,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_10Hz = 0x08,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_25Hz = 0x10,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_50Hz = 0x18,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_100Hz = 0x20,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_200Hz = 0x28,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_400Hz = 0x30,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_800Hz = 0x38,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_1600Hz = 0x40,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_3300Hz = 0x48,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_6600Hz = 0x50,
+    LSM6DS3_ACC_GYRO_ODR_FIFO_13300Hz = 0x58,
 } LSM6DS3_ACC_GYRO_ODR_FIFO_t;
 
 /*******************************************************************************
-* Register      : ORIENT_CFG_G
-* Address       : 0X0B
-* Bit Group Name: ORIENT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : ORIENT_CFG_G
+ * Address       : 0X0B
+ * Bit Group Name: ORIENT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ORIENT_XYZ 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ORIENT_XZY 		 = 0x01,
-    LSM6DS3_ACC_GYRO_ORIENT_YXZ 		 = 0x02,
-    LSM6DS3_ACC_GYRO_ORIENT_YZX 		 = 0x03,
-    LSM6DS3_ACC_GYRO_ORIENT_ZXY 		 = 0x04,
-    LSM6DS3_ACC_GYRO_ORIENT_ZYX 		 = 0x05,
+    LSM6DS3_ACC_GYRO_ORIENT_XYZ = 0x00,
+    LSM6DS3_ACC_GYRO_ORIENT_XZY = 0x01,
+    LSM6DS3_ACC_GYRO_ORIENT_YXZ = 0x02,
+    LSM6DS3_ACC_GYRO_ORIENT_YZX = 0x03,
+    LSM6DS3_ACC_GYRO_ORIENT_ZXY = 0x04,
+    LSM6DS3_ACC_GYRO_ORIENT_ZYX = 0x05,
 } LSM6DS3_ACC_GYRO_ORIENT_t;
 
 /*******************************************************************************
-* Register      : ORIENT_CFG_G
-* Address       : 0X0B
-* Bit Group Name: SIGN_Z_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : ORIENT_CFG_G
+ * Address       : 0X0B
+ * Bit Group Name: SIGN_Z_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIGN_Z_G_POSITIVE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIGN_Z_G_NEGATIVE 		 = 0x08,
+    LSM6DS3_ACC_GYRO_SIGN_Z_G_POSITIVE = 0x00,
+    LSM6DS3_ACC_GYRO_SIGN_Z_G_NEGATIVE = 0x08,
 } LSM6DS3_ACC_GYRO_SIGN_Z_G_t;
 
 /*******************************************************************************
-* Register      : ORIENT_CFG_G
-* Address       : 0X0B
-* Bit Group Name: SIGN_Y_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : ORIENT_CFG_G
+ * Address       : 0X0B
+ * Bit Group Name: SIGN_Y_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIGN_Y_G_POSITIVE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIGN_Y_G_NEGATIVE 		 = 0x10,
+    LSM6DS3_ACC_GYRO_SIGN_Y_G_POSITIVE = 0x00,
+    LSM6DS3_ACC_GYRO_SIGN_Y_G_NEGATIVE = 0x10,
 } LSM6DS3_ACC_GYRO_SIGN_Y_G_t;
 
 /*******************************************************************************
-* Register      : ORIENT_CFG_G
-* Address       : 0X0B
-* Bit Group Name: SIGN_X_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : ORIENT_CFG_G
+ * Address       : 0X0B
+ * Bit Group Name: SIGN_X_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIGN_X_G_POSITIVE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIGN_X_G_NEGATIVE 		 = 0x20,
+    LSM6DS3_ACC_GYRO_SIGN_X_G_POSITIVE = 0x00,
+    LSM6DS3_ACC_GYRO_SIGN_X_G_NEGATIVE = 0x20,
 } LSM6DS3_ACC_GYRO_SIGN_X_G_t;
 
 /*******************************************************************************
-* Register      : REFERENCE_G
-* Address       : 0X0C
-* Bit Group Name: REF_G
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_REF_G_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_REF_G_POSITION  	0
+ * Register      : REFERENCE_G
+ * Address       : 0X0C
+ * Bit Group Name: REF_G
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_REF_G_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_REF_G_POSITION 0
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_DRDY_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_DRDY_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_DRDY_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_DRDY_XL_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_INT1_DRDY_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_DRDY_XL_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_DRDY_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_DRDY_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_DRDY_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_DRDY_G_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_INT1_DRDY_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_DRDY_G_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_INT1_DRDY_G_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_BOOT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_BOOT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_BOOT_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_BOOT_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_INT1_BOOT_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_BOOT_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_INT1_BOOT_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_FTH
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_FTH
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_FTH_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_FTH_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_INT1_FTH_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_FTH_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_INT1_FTH_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_OVR
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_OVR
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_OVR_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_OVR_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_INT1_OVR_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_OVR_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_INT1_OVR_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_FSS5
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_FSS5
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_FSS5_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_FSS5_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT1_FSS5_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_FSS5_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_INT1_FSS5_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_SIGN_MOT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_SIGN_MOT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t;
 
 /*******************************************************************************
-* Register      : INT1_CTRL
-* Address       : 0X0D
-* Bit Group Name: INT1_PEDO
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT1_CTRL
+ * Address       : 0X0D
+ * Bit Group Name: INT1_PEDO
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_PEDO_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_PEDO_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_INT1_PEDO_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_PEDO_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_INT1_PEDO_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_DRDY_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_DRDY_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_DRDY_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_DRDY_XL_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_INT2_DRDY_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_DRDY_XL_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_DRDY_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_DRDY_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_DRDY_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_DRDY_G_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_INT2_DRDY_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_DRDY_G_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_INT2_DRDY_G_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_FTH
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_FTH
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_FTH_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_FTH_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_INT2_FTH_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_FTH_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_INT2_FTH_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_OVR
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_OVR
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_OVR_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_OVR_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_INT2_OVR_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_OVR_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_INT2_OVR_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_FSS5
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_FSS5
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_FSS5_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_FSS5_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT2_FSS5_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_FSS5_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_INT2_FSS5_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_SIGN_MOT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_SIGN_MOT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t;
 
 /*******************************************************************************
-* Register      : INT2_CTRL
-* Address       : 0X0E
-* Bit Group Name: INT2_PEDO
-* Permission    : RW
-*******************************************************************************/
+ * Register      : INT2_CTRL
+ * Address       : 0X0E
+ * Bit Group Name: INT2_PEDO
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_PEDO_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_PEDO_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_INT2_PEDO_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_PEDO_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_INT2_PEDO_t;
 
 /*******************************************************************************
-* Register      : WHO_AM_I
-* Address       : 0X0F
-* Bit Group Name: WHO_AM_I_BIT
-* Permission    : RO
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_POSITION  	0
+ * Register      : WHO_AM_I
+ * Address       : 0X0F
+ * Bit Group Name: WHO_AM_I_BIT
+ * Permission    : RO
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_POSITION 0
 
 /*******************************************************************************
-* Register      : CTRL1_XL
-* Address       : 0X10
-* Bit Group Name: BW_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL1_XL
+ * Address       : 0X10
+ * Bit Group Name: BW_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_BW_XL_400Hz 		 = 0x00,
-    LSM6DS3_ACC_GYRO_BW_XL_200Hz 		 = 0x01,
-    LSM6DS3_ACC_GYRO_BW_XL_100Hz 		 = 0x02,
-    LSM6DS3_ACC_GYRO_BW_XL_50Hz 		 = 0x03,
+    LSM6DS3_ACC_GYRO_BW_XL_400Hz = 0x00,
+    LSM6DS3_ACC_GYRO_BW_XL_200Hz = 0x01,
+    LSM6DS3_ACC_GYRO_BW_XL_100Hz = 0x02,
+    LSM6DS3_ACC_GYRO_BW_XL_50Hz = 0x03,
 } LSM6DS3_ACC_GYRO_BW_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL1_XL
-* Address       : 0X10
-* Bit Group Name: FS_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL1_XL
+ * Address       : 0X10
+ * Bit Group Name: FS_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FS_XL_2g 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FS_XL_16g 		 = 0x04,
-    LSM6DS3_ACC_GYRO_FS_XL_4g 		 = 0x08,
-    LSM6DS3_ACC_GYRO_FS_XL_8g 		 = 0x0C,
+    LSM6DS3_ACC_GYRO_FS_XL_2g = 0x00,
+    LSM6DS3_ACC_GYRO_FS_XL_16g = 0x04,
+    LSM6DS3_ACC_GYRO_FS_XL_4g = 0x08,
+    LSM6DS3_ACC_GYRO_FS_XL_8g = 0x0C,
 } LSM6DS3_ACC_GYRO_FS_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL1_XL
-* Address       : 0X10
-* Bit Group Name: ODR_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL1_XL
+ * Address       : 0X10
+ * Bit Group Name: ODR_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ODR_XL_POWER_DOWN 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ODR_XL_13Hz 		         = 0x10,
-    LSM6DS3_ACC_GYRO_ODR_XL_26Hz 		         = 0x20,
-    LSM6DS3_ACC_GYRO_ODR_XL_52Hz 		         = 0x30,
-    LSM6DS3_ACC_GYRO_ODR_XL_104Hz 		 = 0x40,
-    LSM6DS3_ACC_GYRO_ODR_XL_208Hz 		 = 0x50,
-    LSM6DS3_ACC_GYRO_ODR_XL_416Hz 		 = 0x60,
-    LSM6DS3_ACC_GYRO_ODR_XL_833Hz 		 = 0x70,
-    LSM6DS3_ACC_GYRO_ODR_XL_1660Hz 		 = 0x80,
-    LSM6DS3_ACC_GYRO_ODR_XL_3330Hz 		 = 0x90,
-    LSM6DS3_ACC_GYRO_ODR_XL_6660Hz 		 = 0xA0,
-    LSM6DS3_ACC_GYRO_ODR_XL_13330Hz 		 = 0xB0,
+    LSM6DS3_ACC_GYRO_ODR_XL_POWER_DOWN = 0x00,
+    LSM6DS3_ACC_GYRO_ODR_XL_13Hz = 0x10,
+    LSM6DS3_ACC_GYRO_ODR_XL_26Hz = 0x20,
+    LSM6DS3_ACC_GYRO_ODR_XL_52Hz = 0x30,
+    LSM6DS3_ACC_GYRO_ODR_XL_104Hz = 0x40,
+    LSM6DS3_ACC_GYRO_ODR_XL_208Hz = 0x50,
+    LSM6DS3_ACC_GYRO_ODR_XL_416Hz = 0x60,
+    LSM6DS3_ACC_GYRO_ODR_XL_833Hz = 0x70,
+    LSM6DS3_ACC_GYRO_ODR_XL_1660Hz = 0x80,
+    LSM6DS3_ACC_GYRO_ODR_XL_3330Hz = 0x90,
+    LSM6DS3_ACC_GYRO_ODR_XL_6660Hz = 0xA0,
+    LSM6DS3_ACC_GYRO_ODR_XL_13330Hz = 0xB0,
 } LSM6DS3_ACC_GYRO_ODR_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL2_G
-* Address       : 0X11
-* Bit Group Name: FS_125
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL2_G
+ * Address       : 0X11
+ * Bit Group Name: FS_125
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FS_125_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FS_125_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_FS_125_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_FS_125_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_FS_125_t;
 
 /*******************************************************************************
-* Register      : CTRL2_G
-* Address       : 0X11
-* Bit Group Name: FS_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL2_G
+ * Address       : 0X11
+ * Bit Group Name: FS_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FS_G_245dps 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FS_G_500dps 		 = 0x04,
-    LSM6DS3_ACC_GYRO_FS_G_1000dps 		 = 0x08,
-    LSM6DS3_ACC_GYRO_FS_G_2000dps 		 = 0x0C,
+    LSM6DS3_ACC_GYRO_FS_G_245dps = 0x00,
+    LSM6DS3_ACC_GYRO_FS_G_500dps = 0x04,
+    LSM6DS3_ACC_GYRO_FS_G_1000dps = 0x08,
+    LSM6DS3_ACC_GYRO_FS_G_2000dps = 0x0C,
 } LSM6DS3_ACC_GYRO_FS_G_t;
 
 /*******************************************************************************
-* Register      : CTRL2_G
-* Address       : 0X11
-* Bit Group Name: ODR_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL2_G
+ * Address       : 0X11
+ * Bit Group Name: ODR_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ODR_G_POWER_DOWN 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ODR_G_13Hz 		 = 0x10,
-    LSM6DS3_ACC_GYRO_ODR_G_26Hz 		 = 0x20,
-    LSM6DS3_ACC_GYRO_ODR_G_52Hz 		 = 0x30,
-    LSM6DS3_ACC_GYRO_ODR_G_104Hz 		 = 0x40,
-    LSM6DS3_ACC_GYRO_ODR_G_208Hz 		 = 0x50,
-    LSM6DS3_ACC_GYRO_ODR_G_416Hz 		 = 0x60,
-    LSM6DS3_ACC_GYRO_ODR_G_833Hz 		 = 0x70,
-    LSM6DS3_ACC_GYRO_ODR_G_1660Hz 		 = 0x80,
+    LSM6DS3_ACC_GYRO_ODR_G_POWER_DOWN = 0x00,
+    LSM6DS3_ACC_GYRO_ODR_G_13Hz = 0x10,
+    LSM6DS3_ACC_GYRO_ODR_G_26Hz = 0x20,
+    LSM6DS3_ACC_GYRO_ODR_G_52Hz = 0x30,
+    LSM6DS3_ACC_GYRO_ODR_G_104Hz = 0x40,
+    LSM6DS3_ACC_GYRO_ODR_G_208Hz = 0x50,
+    LSM6DS3_ACC_GYRO_ODR_G_416Hz = 0x60,
+    LSM6DS3_ACC_GYRO_ODR_G_833Hz = 0x70,
+    LSM6DS3_ACC_GYRO_ODR_G_1660Hz = 0x80,
 } LSM6DS3_ACC_GYRO_ODR_G_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: SW_RESET
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: SW_RESET
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SW_RESET_NORMAL_MODE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SW_RESET_RESET_DEVICE 		 = 0x01,
+    LSM6DS3_ACC_GYRO_SW_RESET_NORMAL_MODE = 0x00,
+    LSM6DS3_ACC_GYRO_SW_RESET_RESET_DEVICE = 0x01,
 } LSM6DS3_ACC_GYRO_SW_RESET_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: BLE
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: BLE
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_BLE_LSB 		 = 0x00,
-    LSM6DS3_ACC_GYRO_BLE_MSB 		 = 0x02,
+    LSM6DS3_ACC_GYRO_BLE_LSB = 0x00,
+    LSM6DS3_ACC_GYRO_BLE_MSB = 0x02,
 } LSM6DS3_ACC_GYRO_BLE_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: IF_INC
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: IF_INC
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_IF_INC_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_IF_INC_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_IF_INC_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_IF_INC_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_IF_INC_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: SIM
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: SIM
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIM_4_WIRE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIM_3_WIRE 		 = 0x08,
+    LSM6DS3_ACC_GYRO_SIM_4_WIRE = 0x00,
+    LSM6DS3_ACC_GYRO_SIM_3_WIRE = 0x08,
 } LSM6DS3_ACC_GYRO_SIM_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: PP_OD
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: PP_OD
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PP_OD_PUSH_PULL 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PP_OD_OPEN_DRAIN 		 = 0x10,
+    LSM6DS3_ACC_GYRO_PP_OD_PUSH_PULL = 0x00,
+    LSM6DS3_ACC_GYRO_PP_OD_OPEN_DRAIN = 0x10,
 } LSM6DS3_ACC_GYRO_PP_OD_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: INT_ACT_LEVEL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: INT_ACT_LEVEL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_ACTIVE_HI 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_ACTIVE_LO 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_ACTIVE_HI = 0x00,
+    LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_ACTIVE_LO = 0x20,
 } LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: BDU
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: BDU
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_BDU_CONTINUOS 		 = 0x00,
-    LSM6DS3_ACC_GYRO_BDU_BLOCK_UPDATE 		 = 0x40,
+    LSM6DS3_ACC_GYRO_BDU_CONTINUOS = 0x00,
+    LSM6DS3_ACC_GYRO_BDU_BLOCK_UPDATE = 0x40,
 } LSM6DS3_ACC_GYRO_BDU_t;
 
 /*******************************************************************************
-* Register      : CTRL3_C
-* Address       : 0X12
-* Bit Group Name: BOOT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL3_C
+ * Address       : 0X12
+ * Bit Group Name: BOOT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_BOOT_NORMAL_MODE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_BOOT_REBOOT_MODE 		 = 0x80,
+    LSM6DS3_ACC_GYRO_BOOT_NORMAL_MODE = 0x00,
+    LSM6DS3_ACC_GYRO_BOOT_REBOOT_MODE = 0x80,
 } LSM6DS3_ACC_GYRO_BOOT_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: STOP_ON_FTH
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: STOP_ON_FTH
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_STOP_ON_FTH_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_STOP_ON_FTH_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_STOP_ON_FTH_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_STOP_ON_FTH_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_STOP_ON_FTH_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: MODE3_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: MODE3_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_MODE3_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_MODE3_EN_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_MODE3_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_MODE3_EN_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_MODE3_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: I2C_DISABLE
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: I2C_DISABLE
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_I2C_DISABLE_I2C_AND_SPI 		 = 0x00,
-    LSM6DS3_ACC_GYRO_I2C_DISABLE_SPI_ONLY 		 = 0x04,
+    LSM6DS3_ACC_GYRO_I2C_DISABLE_I2C_AND_SPI = 0x00,
+    LSM6DS3_ACC_GYRO_I2C_DISABLE_SPI_ONLY = 0x04,
 } LSM6DS3_ACC_GYRO_I2C_DISABLE_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: DRDY_MSK
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: DRDY_MSK
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DRDY_MSK_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DRDY_MSK_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_DRDY_MSK_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_DRDY_MSK_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_DRDY_MSK_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: FIFO_TEMP_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: FIFO_TEMP_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: INT2_ON_INT1
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: INT2_ON_INT1
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_ON_INT1_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_ON_INT1_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT2_ON_INT1_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_ON_INT1_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_INT2_ON_INT1_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: SLEEP_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: SLEEP_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SLEEP_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SLEEP_G_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_SLEEP_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_SLEEP_G_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_SLEEP_G_t;
 
 /*******************************************************************************
-* Register      : CTRL4_C
-* Address       : 0X13
-* Bit Group Name: BW_SCAL_ODR
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL4_C
+ * Address       : 0X13
+ * Bit Group Name: BW_SCAL_ODR
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_BW_SCAL_ODR_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_BW_SCAL_ODR_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_BW_SCAL_ODR_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_BW_SCAL_ODR_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t;
 
 /*******************************************************************************
-* Register      : CTRL5_C
-* Address       : 0X14
-* Bit Group Name: ST_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL5_C
+ * Address       : 0X14
+ * Bit Group Name: ST_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ST_XL_NORMAL_MODE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ST_XL_POS_SIGN_TEST 		 = 0x01,
-    LSM6DS3_ACC_GYRO_ST_XL_NEG_SIGN_TEST 		 = 0x02,
-    LSM6DS3_ACC_GYRO_ST_XL_NA 		 = 0x03,
+    LSM6DS3_ACC_GYRO_ST_XL_NORMAL_MODE = 0x00,
+    LSM6DS3_ACC_GYRO_ST_XL_POS_SIGN_TEST = 0x01,
+    LSM6DS3_ACC_GYRO_ST_XL_NEG_SIGN_TEST = 0x02,
+    LSM6DS3_ACC_GYRO_ST_XL_NA = 0x03,
 } LSM6DS3_ACC_GYRO_ST_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL5_C
-* Address       : 0X14
-* Bit Group Name: ST_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL5_C
+ * Address       : 0X14
+ * Bit Group Name: ST_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ST_G_NORMAL_MODE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ST_G_POS_SIGN_TEST 		 = 0x04,
-    LSM6DS3_ACC_GYRO_ST_G_NA 		 = 0x08,
-    LSM6DS3_ACC_GYRO_ST_G_NEG_SIGN_TEST 		 = 0x0C,
+    LSM6DS3_ACC_GYRO_ST_G_NORMAL_MODE = 0x00,
+    LSM6DS3_ACC_GYRO_ST_G_POS_SIGN_TEST = 0x04,
+    LSM6DS3_ACC_GYRO_ST_G_NA = 0x08,
+    LSM6DS3_ACC_GYRO_ST_G_NEG_SIGN_TEST = 0x0C,
 } LSM6DS3_ACC_GYRO_ST_G_t;
 
 /*******************************************************************************
-* Register      : CTRL6_G
-* Address       : 0X15
-* Bit Group Name: LP_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL6_G
+ * Address       : 0X15
+ * Bit Group Name: LP_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_LP_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_LP_XL_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_LP_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_LP_XL_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_LP_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL6_G
-* Address       : 0X15
-* Bit Group Name: DEN_LVL2_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL6_G
+ * Address       : 0X15
+ * Bit Group Name: DEN_LVL2_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEN_LVL2_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEN_LVL2_EN_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_DEN_LVL2_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_DEN_LVL2_EN_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL6_G
-* Address       : 0X15
-* Bit Group Name: DEN_LVL_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL6_G
+ * Address       : 0X15
+ * Bit Group Name: DEN_LVL_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEN_LVL_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEN_LVL_EN_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_DEN_LVL_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_DEN_LVL_EN_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_DEN_LVL_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL6_G
-* Address       : 0X15
-* Bit Group Name: DEN_EDGE_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL6_G
+ * Address       : 0X15
+ * Bit Group Name: DEN_EDGE_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DEN_EDGE_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DEN_EDGE_EN_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_DEN_EDGE_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_DEN_EDGE_EN_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL7_G
-* Address       : 0X16
-* Bit Group Name: HPM_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL7_G
+ * Address       : 0X16
+ * Bit Group Name: HPM_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_HPM_G_NORMAL_MODE 		 = 0x00,
-    LSM6DS3_ACC_GYRO_HPM_G_REF_SIGNAL 		 = 0x10,
-    LSM6DS3_ACC_GYRO_HPM_G_NORMAL_MODE_2 		 = 0x20,
-    LSM6DS3_ACC_GYRO_HPM_G_AUTO_RESET_ON_INT 		 = 0x30,
+    LSM6DS3_ACC_GYRO_HPM_G_NORMAL_MODE = 0x00,
+    LSM6DS3_ACC_GYRO_HPM_G_REF_SIGNAL = 0x10,
+    LSM6DS3_ACC_GYRO_HPM_G_NORMAL_MODE_2 = 0x20,
+    LSM6DS3_ACC_GYRO_HPM_G_AUTO_RESET_ON_INT = 0x30,
 } LSM6DS3_ACC_GYRO_HPM_G_t;
 
 /*******************************************************************************
-* Register      : CTRL7_G
-* Address       : 0X16
-* Bit Group Name: HP_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL7_G
+ * Address       : 0X16
+ * Bit Group Name: HP_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_HP_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_HP_EN_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_HP_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_HP_EN_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_HP_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL7_G
-* Address       : 0X16
-* Bit Group Name: LP_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL7_G
+ * Address       : 0X16
+ * Bit Group Name: LP_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_LP_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_LP_EN_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_LP_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_LP_EN_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_LP_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL8_XL
-* Address       : 0X17
-* Bit Group Name: FDS
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL8_XL
+ * Address       : 0X17
+ * Bit Group Name: FDS
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FDS_FILTER_OFF 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FDS_FILTER_ON 		 = 0x04,
+    LSM6DS3_ACC_GYRO_FDS_FILTER_OFF = 0x00,
+    LSM6DS3_ACC_GYRO_FDS_FILTER_ON = 0x04,
 } LSM6DS3_ACC_GYRO_FDS_t;
 
 /*******************************************************************************
-* Register      : CTRL9_XL
-* Address       : 0X18
-* Bit Group Name: XEN_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL9_XL
+ * Address       : 0X18
+ * Bit Group Name: XEN_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_XEN_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_XEN_XL_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_XEN_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_XEN_XL_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_XEN_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL9_XL
-* Address       : 0X18
-* Bit Group Name: YEN_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL9_XL
+ * Address       : 0X18
+ * Bit Group Name: YEN_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_YEN_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_YEN_XL_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_YEN_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_YEN_XL_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_YEN_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL9_XL
-* Address       : 0X18
-* Bit Group Name: ZEN_XL
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL9_XL
+ * Address       : 0X18
+ * Bit Group Name: ZEN_XL
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ZEN_XL_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ZEN_XL_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_ZEN_XL_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_ZEN_XL_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_ZEN_XL_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: SIGN_MOTION_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: SIGN_MOTION_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: PEDO_RST_STEP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: PEDO_RST_STEP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PEDO_RST_STEP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PEDO_RST_STEP_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_PEDO_RST_STEP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_PEDO_RST_STEP_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: XEN_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: XEN_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_XEN_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_XEN_G_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_XEN_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_XEN_G_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_XEN_G_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: YEN_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: YEN_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_YEN_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_YEN_G_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_YEN_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_YEN_G_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_YEN_G_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: ZEN_G
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: ZEN_G
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_ZEN_G_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_ZEN_G_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_ZEN_G_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_ZEN_G_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_ZEN_G_t;
 
 /*******************************************************************************
-* Register      : CTRL10_C
-* Address       : 0X19
-* Bit Group Name: FUNC_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : CTRL10_C
+ * Address       : 0X19
+ * Bit Group Name: FUNC_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FUNC_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FUNC_EN_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_FUNC_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_FUNC_EN_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_FUNC_EN_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: MASTER_ON
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: MASTER_ON
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_MASTER_ON_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_MASTER_ON_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_MASTER_ON_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_MASTER_ON_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_MASTER_ON_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: IRON_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: IRON_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_IRON_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_IRON_EN_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_IRON_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_IRON_EN_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_IRON_EN_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: PASS_THRU_MODE
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: PASS_THRU_MODE
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PASS_THRU_MODE_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PASS_THRU_MODE_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_PASS_THRU_MODE_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_PASS_THRU_MODE_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: PULL_UP_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: PULL_UP_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PULL_UP_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PULL_UP_EN_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_PULL_UP_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_PULL_UP_EN_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_PULL_UP_EN_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: START_CONFIG
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: START_CONFIG
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_START_CONFIG_XL_G_DRDY 		 = 0x00,
-    LSM6DS3_ACC_GYRO_START_CONFIG_EXT_INT2 		 = 0x10,
+    LSM6DS3_ACC_GYRO_START_CONFIG_XL_G_DRDY = 0x00,
+    LSM6DS3_ACC_GYRO_START_CONFIG_EXT_INT2 = 0x10,
 } LSM6DS3_ACC_GYRO_START_CONFIG_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: DATA_VAL_SEL_FIFO
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: DATA_VAL_SEL_FIFO
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_XL_G_DRDY 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_SHUB_DRDY 		 = 0x40,
+    LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_XL_G_DRDY = 0x00,
+    LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_SHUB_DRDY = 0x40,
 } LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t;
 
 /*******************************************************************************
-* Register      : MASTER_CONFIG
-* Address       : 0X1A
-* Bit Group Name: DRDY_ON_INT1
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MASTER_CONFIG
+ * Address       : 0X1A
+ * Bit Group Name: DRDY_ON_INT1
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DRDY_ON_INT1_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DRDY_ON_INT1_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_DRDY_ON_INT1_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_DRDY_ON_INT1_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: Z_WU
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: Z_WU
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_Z_WU_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_Z_WU_DETECTED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_Z_WU_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_Z_WU_DETECTED = 0x01,
 } LSM6DS3_ACC_GYRO_Z_WU_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: Y_WU
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: Y_WU
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_Y_WU_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_Y_WU_DETECTED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_Y_WU_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_Y_WU_DETECTED = 0x02,
 } LSM6DS3_ACC_GYRO_Y_WU_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: X_WU
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: X_WU
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_X_WU_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_X_WU_DETECTED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_X_WU_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_X_WU_DETECTED = 0x04,
 } LSM6DS3_ACC_GYRO_X_WU_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: WU_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: WU_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_WU_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_WU_EV_STATUS_DETECTED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_WU_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_WU_EV_STATUS_DETECTED = 0x08,
 } LSM6DS3_ACC_GYRO_WU_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: SLEEP_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: SLEEP_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_DETECTED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_DETECTED = 0x10,
 } LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_SRC
-* Address       : 0X1B
-* Bit Group Name: FF_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : WAKE_UP_SRC
+ * Address       : 0X1B
+ * Bit Group Name: FF_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FF_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FF_EV_STATUS_DETECTED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_FF_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_FF_EV_STATUS_DETECTED = 0x20,
 } LSM6DS3_ACC_GYRO_FF_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: Z_TAP
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: Z_TAP
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_Z_TAP_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_Z_TAP_DETECTED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_Z_TAP_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_Z_TAP_DETECTED = 0x01,
 } LSM6DS3_ACC_GYRO_Z_TAP_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: Y_TAP
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: Y_TAP
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_Y_TAP_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_Y_TAP_DETECTED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_Y_TAP_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_Y_TAP_DETECTED = 0x02,
 } LSM6DS3_ACC_GYRO_Y_TAP_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: X_TAP
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: X_TAP
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_X_TAP_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_X_TAP_DETECTED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_X_TAP_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_X_TAP_DETECTED = 0x04,
 } LSM6DS3_ACC_GYRO_X_TAP_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: TAP_SIGN
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: TAP_SIGN
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TAP_SIGN_POS_SIGN 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TAP_SIGN_NEG_SIGN 		 = 0x08,
+    LSM6DS3_ACC_GYRO_TAP_SIGN_POS_SIGN = 0x00,
+    LSM6DS3_ACC_GYRO_TAP_SIGN_NEG_SIGN = 0x08,
 } LSM6DS3_ACC_GYRO_TAP_SIGN_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: DOUBLE_TAP_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: DOUBLE_TAP_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_DETECTED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_DETECTED = 0x10,
 } LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: SINGLE_TAP_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: SINGLE_TAP_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_DETECTED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_DETECTED = 0x20,
 } LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : TAP_SRC
-* Address       : 0X1C
-* Bit Group Name: TAP_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : TAP_SRC
+ * Address       : 0X1C
+ * Bit Group Name: TAP_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TAP_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TAP_EV_STATUS_DETECTED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_TAP_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_TAP_EV_STATUS_DETECTED = 0x40,
 } LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_XL
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_XL
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_XL_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_XL_DETECTED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_DSD_XL_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_XL_DETECTED = 0x01,
 } LSM6DS3_ACC_GYRO_DSD_XL_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_XH
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_XH
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_XH_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_XH_DETECTED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_DSD_XH_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_XH_DETECTED = 0x02,
 } LSM6DS3_ACC_GYRO_DSD_XH_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_YL
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_YL
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_YL_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_YL_DETECTED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_DSD_YL_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_YL_DETECTED = 0x04,
 } LSM6DS3_ACC_GYRO_DSD_YL_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_YH
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_YH
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_YH_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_YH_DETECTED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_DSD_YH_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_YH_DETECTED = 0x08,
 } LSM6DS3_ACC_GYRO_DSD_YH_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_ZL
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_ZL
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_ZL_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_ZL_DETECTED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_DSD_ZL_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_ZL_DETECTED = 0x10,
 } LSM6DS3_ACC_GYRO_DSD_ZL_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: DSD_ZH
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: DSD_ZH
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_DSD_ZH_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_DSD_ZH_DETECTED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_DSD_ZH_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_DSD_ZH_DETECTED = 0x20,
 } LSM6DS3_ACC_GYRO_DSD_ZH_t;
 
 /*******************************************************************************
-* Register      : D6D_SRC
-* Address       : 0X1D
-* Bit Group Name: D6D_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : D6D_SRC
+ * Address       : 0X1D
+ * Bit Group Name: D6D_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_D6D_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_D6D_EV_STATUS_DETECTED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_D6D_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_D6D_EV_STATUS_DETECTED = 0x40,
 } LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : STATUS_REG
-* Address       : 0X1E
-* Bit Group Name: XLDA
-* Permission    : RO
-*******************************************************************************/
+ * Register      : STATUS_REG
+ * Address       : 0X1E
+ * Bit Group Name: XLDA
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_XLDA_NO_DATA_AVAIL 		 = 0x00,
-    LSM6DS3_ACC_GYRO_XLDA_DATA_AVAIL 		 = 0x01,
+    LSM6DS3_ACC_GYRO_XLDA_NO_DATA_AVAIL = 0x00,
+    LSM6DS3_ACC_GYRO_XLDA_DATA_AVAIL = 0x01,
 } LSM6DS3_ACC_GYRO_XLDA_t;
 
 /*******************************************************************************
-* Register      : STATUS_REG
-* Address       : 0X1E
-* Bit Group Name: GDA
-* Permission    : RO
-*******************************************************************************/
+ * Register      : STATUS_REG
+ * Address       : 0X1E
+ * Bit Group Name: GDA
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_GDA_NO_DATA_AVAIL 		 = 0x00,
-    LSM6DS3_ACC_GYRO_GDA_DATA_AVAIL 		 = 0x02,
+    LSM6DS3_ACC_GYRO_GDA_NO_DATA_AVAIL = 0x00,
+    LSM6DS3_ACC_GYRO_GDA_DATA_AVAIL = 0x02,
 } LSM6DS3_ACC_GYRO_GDA_t;
 
 /*******************************************************************************
-* Register      : STATUS_REG
-* Address       : 0X1E
-* Bit Group Name: EV_BOOT
-* Permission    : RO
-*******************************************************************************/
+ * Register      : STATUS_REG
+ * Address       : 0X1E
+ * Bit Group Name: EV_BOOT
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_EV_BOOT_NO_BOOT_RUNNING 		 = 0x00,
-    LSM6DS3_ACC_GYRO_EV_BOOT_BOOT_IS_RUNNING 		 = 0x08,
+    LSM6DS3_ACC_GYRO_EV_BOOT_NO_BOOT_RUNNING = 0x00,
+    LSM6DS3_ACC_GYRO_EV_BOOT_BOOT_IS_RUNNING = 0x08,
 } LSM6DS3_ACC_GYRO_EV_BOOT_t;
 
 /*******************************************************************************
-* Register      : FIFO_STATUS1
-* Address       : 0X3A
-* Bit Group Name: DIFF_FIFO
-* Permission    : RO
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS1_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS1_POSITION  	0
-#define  	LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_MASK  0xF
-#define  	LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_POSITION  	0
+ * Register      : FIFO_STATUS1
+ * Address       : 0X3A
+ * Bit Group Name: DIFF_FIFO
+ * Permission    : RO
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS1_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS1_POSITION 0
+#define LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_MASK 0xF
+#define LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_POSITION 0
 
 /*******************************************************************************
-* Register      : FIFO_STATUS2
-* Address       : 0X3B
-* Bit Group Name: FIFO_EMPTY
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FIFO_STATUS2
+ * Address       : 0X3B
+ * Bit Group Name: FIFO_EMPTY
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FIFO_EMPTY_FIFO_NOT_EMPTY 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FIFO_EMPTY_FIFO_EMPTY 		 = 0x10,
+    LSM6DS3_ACC_GYRO_FIFO_EMPTY_FIFO_NOT_EMPTY = 0x00,
+    LSM6DS3_ACC_GYRO_FIFO_EMPTY_FIFO_EMPTY = 0x10,
 } LSM6DS3_ACC_GYRO_FIFO_EMPTY_t;
 
 /*******************************************************************************
-* Register      : FIFO_STATUS2
-* Address       : 0X3B
-* Bit Group Name: FIFO_FULL
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FIFO_STATUS2
+ * Address       : 0X3B
+ * Bit Group Name: FIFO_FULL
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FIFO_FULL_FIFO_NOT_FULL 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FIFO_FULL_FIFO_FULL 		 = 0x20,
+    LSM6DS3_ACC_GYRO_FIFO_FULL_FIFO_NOT_FULL = 0x00,
+    LSM6DS3_ACC_GYRO_FIFO_FULL_FIFO_FULL = 0x20,
 } LSM6DS3_ACC_GYRO_FIFO_FULL_t;
 
 /*******************************************************************************
-* Register      : FIFO_STATUS2
-* Address       : 0X3B
-* Bit Group Name: OVERRUN
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FIFO_STATUS2
+ * Address       : 0X3B
+ * Bit Group Name: OVERRUN
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_OVERRUN_NO_OVERRUN 		 = 0x00,
-    LSM6DS3_ACC_GYRO_OVERRUN_OVERRUN 		 = 0x40,
+    LSM6DS3_ACC_GYRO_OVERRUN_NO_OVERRUN = 0x00,
+    LSM6DS3_ACC_GYRO_OVERRUN_OVERRUN = 0x40,
 } LSM6DS3_ACC_GYRO_OVERRUN_t;
 
 /*******************************************************************************
-* Register      : FIFO_STATUS2
-* Address       : 0X3B
-* Bit Group Name: WTM
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FIFO_STATUS2
+ * Address       : 0X3B
+ * Bit Group Name: WTM
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_WTM_BELOW_WTM 		 = 0x00,
-    LSM6DS3_ACC_GYRO_WTM_ABOVE_OR_EQUAL_WTM 		 = 0x80,
+    LSM6DS3_ACC_GYRO_WTM_BELOW_WTM = 0x00,
+    LSM6DS3_ACC_GYRO_WTM_ABOVE_OR_EQUAL_WTM = 0x80,
 } LSM6DS3_ACC_GYRO_WTM_t;
 
 /*******************************************************************************
-* Register      : FIFO_STATUS3
-* Address       : 0X3C
-* Bit Group Name: FIFO_PATTERN
-* Permission    : RO
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_FIFO_STATUS3_PATTERN_MASK  	0xFF
-#define  	LSM6DS3_ACC_GYRO_FIFO_STATUS3_PATTERN_POSITION  	0
-#define  	LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_MASK  	0x03
-#define  	LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_POSITION  	0
+ * Register      : FIFO_STATUS3
+ * Address       : 0X3C
+ * Bit Group Name: FIFO_PATTERN
+ * Permission    : RO
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS3_PATTERN_MASK 0xFF
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS3_PATTERN_POSITION 0
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_MASK 0x03
+#define LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_POSITION 0
 
 /*******************************************************************************
-* Register      : FUNC_SRC
-* Address       : 0X53
-* Bit Group Name: SENS_HUB_END
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FUNC_SRC
+ * Address       : 0X53
+ * Bit Group Name: SENS_HUB_END
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SENS_HUB_END_STILL_ONGOING 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SENS_HUB_END_OP_COMPLETED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_SENS_HUB_END_STILL_ONGOING = 0x00,
+    LSM6DS3_ACC_GYRO_SENS_HUB_END_OP_COMPLETED = 0x01,
 } LSM6DS3_ACC_GYRO_SENS_HUB_END_t;
 
 /*******************************************************************************
-* Register      : FUNC_SRC
-* Address       : 0X53
-* Bit Group Name: SOFT_IRON_END
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FUNC_SRC
+ * Address       : 0X53
+ * Bit Group Name: SOFT_IRON_END
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SOFT_IRON_END_NOT_COMPLETED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SOFT_IRON_END_COMPLETED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_SOFT_IRON_END_NOT_COMPLETED = 0x00,
+    LSM6DS3_ACC_GYRO_SOFT_IRON_END_COMPLETED = 0x02,
 } LSM6DS3_ACC_GYRO_SOFT_IRON_END_t;
 
 /*******************************************************************************
-* Register      : FUNC_SRC
-* Address       : 0X53
-* Bit Group Name: PEDO_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FUNC_SRC
+ * Address       : 0X53
+ * Bit Group Name: PEDO_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_DETECTED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_DETECTED = 0x10,
 } LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : FUNC_SRC
-* Address       : 0X53
-* Bit Group Name: TILT_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FUNC_SRC
+ * Address       : 0X53
+ * Bit Group Name: TILT_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TILT_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TILT_EV_STATUS_DETECTED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_TILT_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_TILT_EV_STATUS_DETECTED = 0x20,
 } LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : FUNC_SRC
-* Address       : 0X53
-* Bit Group Name: SIGN_MOT_EV_STATUS
-* Permission    : RO
-*******************************************************************************/
+ * Register      : FUNC_SRC
+ * Address       : 0X53
+ * Bit Group Name: SIGN_MOT_EV_STATUS
+ * Permission    : RO
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_NOT_DETECTED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_DETECTED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_NOT_DETECTED = 0x00,
+    LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_DETECTED = 0x40,
 } LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: LIR
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: LIR
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_LIR_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_LIR_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_LIR_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_LIR_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_LIR_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: TAP_Z_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: TAP_Z_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TAP_Z_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TAP_Z_EN_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_TAP_Z_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TAP_Z_EN_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_TAP_Z_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: TAP_Y_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: TAP_Y_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TAP_Y_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TAP_Y_EN_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_TAP_Y_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TAP_Y_EN_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_TAP_Y_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: TAP_X_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: TAP_X_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TAP_X_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TAP_X_EN_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_TAP_X_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TAP_X_EN_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_TAP_X_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: TILT_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: TILT_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TILT_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TILT_EN_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_TILT_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TILT_EN_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_TILT_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: PEDO_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: PEDO_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_PEDO_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_PEDO_EN_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_PEDO_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_PEDO_EN_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_PEDO_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_CFG1
-* Address       : 0X58
-* Bit Group Name: TIMER_EN
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_CFG1
+ * Address       : 0X58
+ * Bit Group Name: TIMER_EN
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TIMER_EN_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TIMER_EN_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_TIMER_EN_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_TIMER_EN_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_TIMER_EN_t;
 
 /*******************************************************************************
-* Register      : TAP_THS_6D
-* Address       : 0X59
-* Bit Group Name: TAP_THS
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_TAP_THS_MASK  	0x1F
-#define  	LSM6DS3_ACC_GYRO_TAP_THS_POSITION  	0
+ * Register      : TAP_THS_6D
+ * Address       : 0X59
+ * Bit Group Name: TAP_THS
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_TAP_THS_MASK 0x1F
+#define LSM6DS3_ACC_GYRO_TAP_THS_POSITION 0
 
 /*******************************************************************************
-* Register      : TAP_THS_6D
-* Address       : 0X59
-* Bit Group Name: SIXD_THS
-* Permission    : RW
-*******************************************************************************/
+ * Register      : TAP_THS_6D
+ * Address       : 0X59
+ * Bit Group Name: SIXD_THS
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SIXD_THS_80_degree 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SIXD_THS_70_degree 		 = 0x20,
-    LSM6DS3_ACC_GYRO_SIXD_THS_60_degree 		 = 0x40,
-    LSM6DS3_ACC_GYRO_SIXD_THS_50_degree 		 = 0x60,
+    LSM6DS3_ACC_GYRO_SIXD_THS_80_degree = 0x00,
+    LSM6DS3_ACC_GYRO_SIXD_THS_70_degree = 0x20,
+    LSM6DS3_ACC_GYRO_SIXD_THS_60_degree = 0x40,
+    LSM6DS3_ACC_GYRO_SIXD_THS_50_degree = 0x60,
 } LSM6DS3_ACC_GYRO_SIXD_THS_t;
 
 /*******************************************************************************
-* Register      : INT_DUR2
-* Address       : 0X5A
-* Bit Group Name: SHOCK
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_SHOCK_MASK  	0x03
-#define  	LSM6DS3_ACC_GYRO_SHOCK_POSITION  	0
+ * Register      : INT_DUR2
+ * Address       : 0X5A
+ * Bit Group Name: SHOCK
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_SHOCK_MASK 0x03
+#define LSM6DS3_ACC_GYRO_SHOCK_POSITION 0
 
 /*******************************************************************************
-* Register      : INT_DUR2
-* Address       : 0X5A
-* Bit Group Name: QUIET
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_QUIET_MASK  	0x0C
-#define  	LSM6DS3_ACC_GYRO_QUIET_POSITION  	2
+ * Register      : INT_DUR2
+ * Address       : 0X5A
+ * Bit Group Name: QUIET
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_QUIET_MASK 0x0C
+#define LSM6DS3_ACC_GYRO_QUIET_POSITION 2
 
 /*******************************************************************************
-* Register      : INT_DUR2
-* Address       : 0X5A
-* Bit Group Name: DUR
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_DUR_MASK  	0xF0
-#define  	LSM6DS3_ACC_GYRO_DUR_POSITION  	4
+ * Register      : INT_DUR2
+ * Address       : 0X5A
+ * Bit Group Name: DUR
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_DUR_MASK 0xF0
+#define LSM6DS3_ACC_GYRO_DUR_POSITION 4
 
 /*******************************************************************************
-* Register      : WAKE_UP_THS
-* Address       : 0X5B
-* Bit Group Name: WK_THS
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_WK_THS_MASK  	0x3F
-#define  	LSM6DS3_ACC_GYRO_WK_THS_POSITION  	0
+ * Register      : WAKE_UP_THS
+ * Address       : 0X5B
+ * Bit Group Name: WK_THS
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_WK_THS_MASK 0x3F
+#define LSM6DS3_ACC_GYRO_WK_THS_POSITION 0
 
 /*******************************************************************************
-* Register      : WAKE_UP_THS
-* Address       : 0X5B
-* Bit Group Name: INACTIVITY_ON
-* Permission    : RW
-*******************************************************************************/
+ * Register      : WAKE_UP_THS
+ * Address       : 0X5B
+ * Bit Group Name: INACTIVITY_ON
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INACTIVITY_ON_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INACTIVITY_ON_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_INACTIVITY_ON_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INACTIVITY_ON_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_INACTIVITY_ON_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_THS
-* Address       : 0X5B
-* Bit Group Name: SINGLE_DOUBLE_TAP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : WAKE_UP_THS
+ * Address       : 0X5B
+ * Bit Group Name: SINGLE_DOUBLE_TAP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_DOUBLE_TAP 		 = 0x00,
-    LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_SINGLE_TAP 		 = 0x80,
+    LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_DOUBLE_TAP = 0x00,
+    LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_SINGLE_TAP = 0x80,
 } LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_DUR
-* Address       : 0X5C
-* Bit Group Name: SLEEP_DUR
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_SLEEP_DUR_MASK  	0x0F
-#define  	LSM6DS3_ACC_GYRO_SLEEP_DUR_POSITION  	0
+ * Register      : WAKE_UP_DUR
+ * Address       : 0X5C
+ * Bit Group Name: SLEEP_DUR
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_SLEEP_DUR_MASK 0x0F
+#define LSM6DS3_ACC_GYRO_SLEEP_DUR_POSITION 0
 
 /*******************************************************************************
-* Register      : WAKE_UP_DUR
-* Address       : 0X5C
-* Bit Group Name: TIMER_HR
-* Permission    : RW
-*******************************************************************************/
+ * Register      : WAKE_UP_DUR
+ * Address       : 0X5C
+ * Bit Group Name: TIMER_HR
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_TIMER_HR_6_4ms 		 = 0x00,
-    LSM6DS3_ACC_GYRO_TIMER_HR_25us 		 = 0x10,
+    LSM6DS3_ACC_GYRO_TIMER_HR_6_4ms = 0x00,
+    LSM6DS3_ACC_GYRO_TIMER_HR_25us = 0x10,
 } LSM6DS3_ACC_GYRO_TIMER_HR_t;
 
 /*******************************************************************************
-* Register      : WAKE_UP_DUR
-* Address       : 0X5C
-* Bit Group Name: WAKE_DUR
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_WAKE_DUR_MASK  	0x60
-#define  	LSM6DS3_ACC_GYRO_WAKE_DUR_POSITION  	5
+ * Register      : WAKE_UP_DUR
+ * Address       : 0X5C
+ * Bit Group Name: WAKE_DUR
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_WAKE_DUR_MASK 0x60
+#define LSM6DS3_ACC_GYRO_WAKE_DUR_POSITION 5
 
 /*******************************************************************************
-* Register      : FREE_FALL
-* Address       : 0X5D
-* Bit Group Name: FF_DUR
-* Permission    : RW
-*******************************************************************************/
-#define  	LSM6DS3_ACC_GYRO_FF_FREE_FALL_DUR_MASK  	0xF8
-#define  	LSM6DS3_ACC_GYRO_FF_FREE_FALL_DUR_POSITION  	3
-#define  	LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_MASK  	0x80
-#define  	LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_POSITION  	7
-
+ * Register      : FREE_FALL
+ * Address       : 0X5D
+ * Bit Group Name: FF_DUR
+ * Permission    : RW
+ *******************************************************************************/
+#define LSM6DS3_ACC_GYRO_FF_FREE_FALL_DUR_MASK 0xF8
+#define LSM6DS3_ACC_GYRO_FF_FREE_FALL_DUR_POSITION 3
+#define LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_MASK 0x80
+#define LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_POSITION 7
 
 /*******************************************************************************
-* Register      : FREE_FALL
-* Address       : 0X5D
-* Bit Group Name: FF_THS
-* Permission    : RW
-*******************************************************************************/
+ * Register      : FREE_FALL
+ * Address       : 0X5D
+ * Bit Group Name: FF_THS
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_FF_THS_5 		 = 0x00,
-    LSM6DS3_ACC_GYRO_FF_THS_7 		 = 0x01,
-    LSM6DS3_ACC_GYRO_FF_THS_8 		 = 0x02,
-    LSM6DS3_ACC_GYRO_FF_THS_10 		 = 0x03,
-    LSM6DS3_ACC_GYRO_FF_THS_11 		 = 0x04,
-    LSM6DS3_ACC_GYRO_FF_THS_13 		 = 0x05,
-    LSM6DS3_ACC_GYRO_FF_THS_15 		 = 0x06,
-    LSM6DS3_ACC_GYRO_FF_THS_16 		 = 0x07,
+    LSM6DS3_ACC_GYRO_FF_THS_5 = 0x00,
+    LSM6DS3_ACC_GYRO_FF_THS_7 = 0x01,
+    LSM6DS3_ACC_GYRO_FF_THS_8 = 0x02,
+    LSM6DS3_ACC_GYRO_FF_THS_10 = 0x03,
+    LSM6DS3_ACC_GYRO_FF_THS_11 = 0x04,
+    LSM6DS3_ACC_GYRO_FF_THS_13 = 0x05,
+    LSM6DS3_ACC_GYRO_FF_THS_15 = 0x06,
+    LSM6DS3_ACC_GYRO_FF_THS_16 = 0x07,
 } LSM6DS3_ACC_GYRO_FF_THS_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_TIMER
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_TIMER
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_TIMER_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_TIMER_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_INT1_TIMER_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_TIMER_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_INT1_TIMER_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_TILT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_TILT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_TILT_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_TILT_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_INT1_TILT_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_TILT_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_INT1_TILT_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_6D
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_6D
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_6D_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_6D_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_INT1_6D_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_6D_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_INT1_6D_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_TAP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_TAP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_TAP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_TAP_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_INT1_TAP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_TAP_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_INT1_TAP_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_FF
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_FF
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_FF_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_FF_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_INT1_FF_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_FF_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_INT1_FF_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_WU
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_WU
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_WU_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_WU_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT1_WU_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_WU_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_INT1_WU_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_SINGLE_TAP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_SINGLE_TAP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t;
 
 /*******************************************************************************
-* Register      : MD1_CFG
-* Address       : 0X5E
-* Bit Group Name: INT1_SLEEP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD1_CFG
+ * Address       : 0X5E
+ * Bit Group Name: INT1_SLEEP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT1_SLEEP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT1_SLEEP_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_INT1_SLEEP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT1_SLEEP_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_INT1_SLEEP_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_TIMER
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_TIMER
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_TIMER_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_TIMER_ENABLED 		 = 0x01,
+    LSM6DS3_ACC_GYRO_INT2_TIMER_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_TIMER_ENABLED = 0x01,
 } LSM6DS3_ACC_GYRO_INT2_TIMER_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_TILT
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_TILT
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_TILT_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_TILT_ENABLED 		 = 0x02,
+    LSM6DS3_ACC_GYRO_INT2_TILT_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_TILT_ENABLED = 0x02,
 } LSM6DS3_ACC_GYRO_INT2_TILT_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_6D
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_6D
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_6D_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_6D_ENABLED 		 = 0x04,
+    LSM6DS3_ACC_GYRO_INT2_6D_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_6D_ENABLED = 0x04,
 } LSM6DS3_ACC_GYRO_INT2_6D_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_TAP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_TAP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_TAP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_TAP_ENABLED 		 = 0x08,
+    LSM6DS3_ACC_GYRO_INT2_TAP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_TAP_ENABLED = 0x08,
 } LSM6DS3_ACC_GYRO_INT2_TAP_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_FF
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_FF
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_FF_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_FF_ENABLED 		 = 0x10,
+    LSM6DS3_ACC_GYRO_INT2_FF_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_FF_ENABLED = 0x10,
 } LSM6DS3_ACC_GYRO_INT2_FF_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_WU
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_WU
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_WU_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_WU_ENABLED 		 = 0x20,
+    LSM6DS3_ACC_GYRO_INT2_WU_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_WU_ENABLED = 0x20,
 } LSM6DS3_ACC_GYRO_INT2_WU_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_SINGLE_TAP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_SINGLE_TAP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_ENABLED 		 = 0x40,
+    LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_ENABLED = 0x40,
 } LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t;
 
 /*******************************************************************************
-* Register      : MD2_CFG
-* Address       : 0X5F
-* Bit Group Name: INT2_SLEEP
-* Permission    : RW
-*******************************************************************************/
+ * Register      : MD2_CFG
+ * Address       : 0X5F
+ * Bit Group Name: INT2_SLEEP
+ * Permission    : RW
+ *******************************************************************************/
 typedef enum {
-    LSM6DS3_ACC_GYRO_INT2_SLEEP_DISABLED 		 = 0x00,
-    LSM6DS3_ACC_GYRO_INT2_SLEEP_ENABLED 		 = 0x80,
+    LSM6DS3_ACC_GYRO_INT2_SLEEP_DISABLED = 0x00,
+    LSM6DS3_ACC_GYRO_INT2_SLEEP_ENABLED = 0x80,
 } LSM6DS3_ACC_GYRO_INT2_SLEEP_t;
 
 #endif

--- a/VL53L0X/README.md
+++ b/VL53L0X/README.md
@@ -2,68 +2,57 @@
 
 Funções auxiliares para serem usadas com o sensor [VL53L0X](https://www.st.com/en/imaging-and-photonics-solutions/vl53l0x.html) da ST Microelectronics. Essa biblioteca foi adaptada da [biblioteca para Arduino](https://github.com/pololu/vl53l0x-arduino) criada pela Pololu, que por sua vez foi inspirada na API oficial da STM, mas não a usa diretamente.
 
-Testado com projetos do STM32CubeMX, usando a biblioteca HAL, e por padrão usa o I2C1, assumindo que ele já está inicializado.
+Testado com projetos do STM32CubeMX, usando a biblioteca HAL.
 
--------
+---
 
 ### Changelog
 
-* 09/2018
-  * Change ADDRESS_DEFAULT to VL53L0X_DEFAULT_ADDRESS to avoid name collisions
-  * Improved in-file documentation
-  * Add VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE, VL53L0X_VCSEL_FINAL_RANGE constant for easier changing
-  * Add VL53L0X_TIMEOUT_RETURN_VALUE
+- 01/2019
+
+  - Remove the need to modify header file, better for submodule use
+    - Remove VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE, VL53L0X_VCSEL_FINAL_RANGE constants;
+    - Add vl53l0x_i2c_set function to set I2C handler, must be called before anything else.
+      Can be called again in case different sensors are connected to different I2C ports.
+  - Change function names to `snake_case`
+
+- 09/2018
+
+  - Change ADDRESS_DEFAULT to VL53L0X_DEFAULT_ADDRESS to avoid name collisions
+  - Improved in-file documentation
+  - Add VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE, VL53L0X_VCSEL_FINAL_RANGE constant for easier changing
+  - Add VL53L0X_TIMEOUT_RETURN_VALUE
 
 ### Funções disponiveis
 
-* `uint8_t vl53l0x_init()`
+- `uint8_t vl53l0x_i2c_set(I2C_HandleTypeDef* hi2c)`
 
-  Essa função deve ser chamada antes de qualquer tentativa de leitura do sensor, ela inicializa o sensor e retorna 1 em caso de sucesso ou 0, em caso de erro.
+  Essa função deve ser chamada antes de qualquer outra, ela define qual I2C deve ser utilizado.
 
-* `void vl53l0x_setDevAddress(uint8_t new_addr)`
+- `uint8_t vl53l0x_init()`
+
+  Essa função deve ser chamada antes de qualquer tentativa de leitura do sensor,
+  ela inicializa o sensor e retorna 1 em caso de sucesso ou 0, em caso de erro.
+
+- `void vl53l0x_set_dev_address(uint8_t new_addr)`
 
   Essa função modifica o endereço I2C do dispositivo atual (8 bits), necessário ao utilizar mais de um sensor.
 
-* `void vl53l0x_setCurrentAddress(uint8_t new_addr)`
+- `void vl53l0x_set_current_address(uint8_t new_addr)`
 
   Essa função muda o endereço do dispositivo utilizado pelas outras funções (8 bits), não acessa os sensores diretamente.
 
-* `void vl53l0x_startContinuous(uint32_t period_ms)`
+- `void vl53l0x_start_continuous(uint32_t period_ms)`
 
-  `void vl53l0x_stopContinuous()`
+  `void vl53l0x_stop_continuous()`
 
   Essas funções iniciam e param a leitura contínua do sensor atual, respectivamente.
 
-* `uint16_t vl53l0x_getRange()`
+- `uint16_t vl53l0x_get_range()`
 
   Essa função retorna o último valor lido do sensor atual.
 
----------
-
-### Modificações
-
-É necessário incluir, em `vl53l0x.h` os arquivos de projeto referentes ao I2C e as definições gerais do HAL, como `stm32f3xx_hal.h`
-
-```c
-// vl53l0x.h
-13    #ifndef _VL53L0X_H_
-14    #define _VL53L0X_H_
-15
-16    // SPECIFIC INCLUDES HERE
-17
-18    /*****************************************
-```
-
-Também em `vl53l0x.h` pode-se mudar as constantes de acordo com o projeto:
-```c
-25    #define VL53L0X_I2C_HANDLER hi2c1      /**< I2C handler */
-26
-27    //! @see setVcselPulsePeriod
-28    #define VL53L0X_VCSEL_PRE_RANGE 18
-29    #define VL53L0X_VCSEL_FINAL_RANGE 14
-```
-
------------
+---
 
 ### Exemplos
 
@@ -71,6 +60,9 @@ Também em `vl53l0x.h` pode-se mudar as constantes de acordo com o projeto:
 
 ```c
 void sensors_init() {
+    // Define o I2C correto
+    vl53l0x_i2c_set(&hi2c2);
+
     // Desativa os dois sensores (Pino XSHUT)
     HAL_GPIO_WritePin(GPIOA, GPIO_PIN_4, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);
@@ -82,7 +74,7 @@ void sensors_init() {
     // Inicializa
     vl53l0x_init();
     // Muda o endereço do sensor
-    vl53l0x_setDevAddress(0x54);
+    vl53l0x_set_dev_address(0x54);
     HAL_Delay(10);
 
     // Ativa o outro sensor
@@ -91,19 +83,19 @@ void sensors_init() {
     // Inicializa
     vl53l0x_init();
     // Muda o endereço do sensor
-    vl53l0x_setDevAddress(0x56);
+    vl53l0x_set_dev_address(0x56);
     HAL_Delay(10);
 
     HAL_Delay(1);
     // Muda o endereço atual das funções
-    vl53l0x_setCurrentAddress(0x54);
+    vl53l0x_set_current_address(0x54);
     // Inicia as medições do primeiro sensor
-    vl53l0x_startContinuous(2);
+    vl53l0x_start_continuous(2);
     HAL_Delay(1);
     // Muda o endereço atual das funções
-    vl53l0x_setCurrentAddress(0x56);
+    vl53l0x_set_current_address(0x56);
     // Inicia as medições do segundo sensor
-    vl53l0x_startContinuous(2);
+    vl53l0x_start_continuous(2);
     HAL_Delay(1);
 }
 ```

--- a/VL53L0X/vl53l0x.c
+++ b/VL53L0X/vl53l0x.c
@@ -11,7 +11,6 @@
  */
 
 #include "vl53l0x.h"
-#include "string.h"
 
 /*****************************************
  * Private Constants
@@ -19,16 +18,20 @@
 
 #define VL53L0X_I2C_TIMEOUT 1000
 
+//! @see setVcselPulsePeriod
+#define VL53L0X_VCSEL_PRE_RANGE 18
+#define VL53L0X_VCSEL_FINAL_RANGE 14
+
 /*****************************************
  * Private Macros
  *****************************************/
 
 #define decodeVcselPeriod(reg_val) (((reg_val) + 1) << 1)
 #define encodeVcselPeriod(period_pclks) (((period_pclks) >> 1) - 1)
-#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks)*1655) + 500) / 1000)
+#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t) 2304 * (vcsel_period_pclks) *1655) + 500) / 1000)
 
-#define startTimeout() (timeout_start_ms = HAL_GetTick())
-#define checkTimeoutExpired() (io_timeout > 0 && ((uint16_t)HAL_GetTick() - timeout_start_ms) > io_timeout)
+#define start_timeout() (timeout_start_ms = HAL_GetTick())
+#define check_timeout_expired() (io_timeout > 0 && ((uint16_t) HAL_GetTick() - timeout_start_ms) > io_timeout)
 
 /*****************************************
  * Private Types
@@ -152,6 +155,7 @@ static uint8_t timeout_start_ms;
 static uint32_t measurement_timing_budget_us;
 
 static HAL_StatusTypeDef status;
+static I2C_HandleTypeDef* i2c_handler;
 
 /*****************************************
  * Private Function Prototypes
@@ -160,14 +164,14 @@ static HAL_StatusTypeDef status;
 /**
  * @brief HAL I2C wrapper functions.
  */
-static void writeReg(uint8_t reg, uint8_t val);
-static void writeReg16(uint8_t reg, uint16_t val);
-static void writeReg32(uint8_t reg, uint32_t val);
-static void writeMulti(uint8_t reg, uint8_t* src, uint8_t count);
-static uint8_t readReg(uint8_t reg);
-static uint16_t readReg16(uint8_t reg);
-static uint32_t readReg32(uint8_t reg);
-static void readMulti(uint8_t reg, uint8_t* dst, uint8_t count);
+static void write_reg(uint8_t reg, uint8_t val);
+static void write_reg16(uint8_t reg, uint16_t val);
+static void write_reg32(uint8_t reg, uint32_t val);
+static void write_multi(uint8_t reg, uint8_t* src, uint8_t count);
+static uint8_t read_reg(uint8_t reg);
+static uint16_t read_reg16(uint8_t reg);
+static uint32_t read_reg32(uint8_t reg);
+static void read_multi(uint8_t reg, uint8_t* dst, uint8_t count);
 
 /**
  * @brief Get reference SPAD (single photon avalanche diode) count and type.
@@ -179,7 +183,7 @@ static void readMulti(uint8_t reg, uint8_t* dst, uint8_t count);
  *
  * @return 0 on failure, 1 on success.
  */
-uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture);
+uint8_t get_spad_info(uint8_t* count, uint8_t* type_is_aperture);
 
 /**
  * @brief Set the measurement timing budget
@@ -195,7 +199,7 @@ uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture);
  *
  * @return 0 on failure, 1 on success.
  */
-uint8_t setMeasurementTimingBudget(uint32_t budget_us);
+uint8_t set_measurement_timing_budget(uint32_t budget_us);
 
 /**
  * @brief Get the measurement timing budget
@@ -204,7 +208,7 @@ uint8_t setMeasurementTimingBudget(uint32_t budget_us);
  *
  * @return Timing budget in microseconds.
  */
-uint32_t getMeasurementTimingBudget();
+uint32_t get_measurement_timing_budget();
 
 /**
  * @brief Set the VCSEL (vertical cavity surface emitting laser) pulse period for the
@@ -221,7 +225,7 @@ uint32_t getMeasurementTimingBudget();
  *
  * @return 0 on failure, 1 on success.
  */
-uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks);
+uint8_t set_vcsel_pulse_period(vcselPeriodType type, uint8_t period_pclks);
 
 /**
  * @brief Get the VCSEL pulse period
@@ -232,7 +236,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks);
  *
  * @return Period in PCLKs.
  */
-uint8_t getVcselPulsePeriod(vcselPeriodType type);
+uint8_t get_vcsel_pulse_period(vcselPeriodType type);
 
 /**
  * @brief Get sequence step enables
@@ -242,7 +246,7 @@ uint8_t getVcselPulsePeriod(vcselPeriodType type);
  * @param enables Pointer to SequenceStepEnables struct where
  *        values will be stored.
  */
-void getSequenceStepEnables(SequenceStepEnables* enables);
+void get_sequence_step_enables(SequenceStepEnables* enables);
 
 /**
  * @brief Get sequence step timeouts
@@ -255,7 +259,7 @@ void getSequenceStepEnables(SequenceStepEnables* enables);
  * @param timeout Pointer to SequenceStepTimeouts struct where values
  *        will be stored.
  */
-void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts);
+void get_sequence_step_timeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts);
 
 /**
  * @brief Decode sequence step timeout in MCLKs from register value.
@@ -268,7 +272,7 @@ void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts*
  *
  * @return Decoded value in MCLKs.
  */
-uint16_t decodeTimeout(uint16_t reg_val);
+uint16_t decode_timeout(uint16_t reg_val);
 
 /**
  * @brief Encode sequence step timeout register value from timeout in MCLKs.
@@ -281,20 +285,20 @@ uint16_t decodeTimeout(uint16_t reg_val);
  *
  * @return Encoded value.
  */
-uint16_t encodeTimeout(uint16_t timeout_mclks);
+uint16_t encode_timeout(uint16_t timeout_mclks);
 
 /**
  * @brief Convert sequence step timeout from MCLKs to microseconds with given VCSEL
  *        period in PCLKs
  *
  * @note Based on VL53L0X_calc_timeout_us().
-
+ *
  * @param timeout_period_mclks Timeout in MCLKs.
  * @param vcsel_period_pclks VCSEL period in PCLKs.
  *
  * @return Timeout in microseconds.
  */
-uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks);
+uint32_t timeout_mclks_to_microseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks);
 
 /**
  * @brief Convert sequence step timeout from microseconds to MCLKs with given VCSEL
@@ -307,72 +311,76 @@ uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel
  *
  * @return Timeout in MCLKs.
  */
-uint32_t timeoutMicrosecondsToMclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks);
+uint32_t timeout_microseconds_to_mclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks);
 
 /**
  * @brief Performs Calibration
  *
  * @note Based on VL53L0X_perform_single_ref_calibration().
-
+ *
  * @param vhv_init_byte
  *
  * @return 0 on failure, 1 on success.
  */
-uint8_t performSingleRefCalibration(uint8_t vhv_init_byte);
+uint8_t perform_single_ref_calibration(uint8_t vhv_init_byte);
 
 /*****************************************
  * Public Function Body Definitions
  *****************************************/
 
-void vl53l0x_setCurrentAddress(uint8_t new_addr) {
+void vl53l0x_i2c_set(I2C_HandleTypeDef* hi2c) {
+    i2c_handler = hi2c;
+}
+
+void vl53l0x_set_current_address(uint8_t new_addr) {
     address = new_addr;
 }
 
-void vl53l0x_setDevAddress(uint8_t new_addr) {
-    writeReg(I2C_SLAVE_DEVICE_ADDRESS, (new_addr >> 1) & 0x7F);
+void vl53l0x_set_dev_address(uint8_t new_addr) {
+    write_reg(I2C_SLAVE_DEVICE_ADDRESS, (new_addr >> 1) & 0x7F);
 }
 
 uint8_t vl53l0x_init() {
-    writeReg(VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV, readReg(VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV) | 0x01);
+    write_reg(VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV, read_reg(VHV_CONFIG_PAD_SCL_SDA__EXTSUP_HV) | 0x01);
 
-    writeReg(0x88, 0x00);
+    write_reg(0x88, 0x00);
 
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    stop_variable = readReg(0x91);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
+    write_reg(0x80, 0x01);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
+    stop_variable = read_reg(0x91);
+    write_reg(0x00, 0x01);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x00);
 
     // disable SIGNAL_RATE_MSRC (bit 1) and SIGNAL_RATE_PRE_RANGE (bit 4) limit
     // checks
-    writeReg(MSRC_CONFIG_CONTROL, readReg(MSRC_CONFIG_CONTROL) | 0x12);
+    write_reg(MSRC_CONFIG_CONTROL, read_reg(MSRC_CONFIG_CONTROL) | 0x12);
 
-    writeReg16(FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT, 0.25 * (1 << 7));
+    write_reg16(FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT, 0.25 * (1 << 7));
 
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0xFF);
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0xFF);
 
     // VL53L0X_StaticInit() begin
 
     uint8_t spad_count;
     uint8_t spad_type_is_aperture;
-    if (!getSpadInfo(&spad_count, &spad_type_is_aperture))
+    if (!get_spad_info(&spad_count, &spad_type_is_aperture))
         return 0;
 
     // The SPAD map (RefGoodSpadMap) is read by VL53L0X_get_info_from_device()
     // in the API, but the same data seems to be more easily readable from
     // GLOBAL_CONFIG_SPAD_ENABLES_REF_0 through _6, so read it from there
     uint8_t ref_spad_map[6];
-    readMulti(GLOBAL_CONFIG_SPAD_ENABLES_REF_0, ref_spad_map, 6);
+    read_multi(GLOBAL_CONFIG_SPAD_ENABLES_REF_0, ref_spad_map, 6);
 
     // -- VL53L0X_set_reference_spads() begin (assume NVM values are valid)
 
-    writeReg(0xFF, 0x01);
-    writeReg(DYNAMIC_SPAD_REF_EN_START_OFFSET, 0x00);
-    writeReg(DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD, 0x2C);
-    writeReg(0xFF, 0x00);
-    writeReg(GLOBAL_CONFIG_REF_EN_START_SELECT, 0xB4);
+    write_reg(0xFF, 0x01);
+    write_reg(DYNAMIC_SPAD_REF_EN_START_OFFSET, 0x00);
+    write_reg(DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD, 0x2C);
+    write_reg(0xFF, 0x00);
+    write_reg(GLOBAL_CONFIG_REF_EN_START_SELECT, 0xB4);
 
     uint8_t first_spad_to_enable = spad_type_is_aperture ? 12 : 0;  // 12 is the first aperture spad
     uint8_t spads_enabled = 0;
@@ -384,132 +392,132 @@ uint8_t vl53l0x_init() {
             spads_enabled++;
     }
 
-    writeMulti(GLOBAL_CONFIG_SPAD_ENABLES_REF_0, ref_spad_map, 6);
+    write_multi(GLOBAL_CONFIG_SPAD_ENABLES_REF_0, ref_spad_map, 6);
 
     // -- VL53L0X_set_reference_spads() end
 
     // -- VL53L0X_load_tuning_settings() begin
     // DefaultTuningSettings from vl53l0x_tuning.h
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x09, 0x00);
-    writeReg(0x10, 0x00);
-    writeReg(0x11, 0x00);
+    write_reg(0xFF, 0x00);
+    write_reg(0x09, 0x00);
+    write_reg(0x10, 0x00);
+    write_reg(0x11, 0x00);
 
-    writeReg(0x24, 0x01);
-    writeReg(0x25, 0xFF);
-    writeReg(0x75, 0x00);
+    write_reg(0x24, 0x01);
+    write_reg(0x25, 0xFF);
+    write_reg(0x75, 0x00);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x4E, 0x2C);
-    writeReg(0x48, 0x00);
-    writeReg(0x30, 0x20);
+    write_reg(0xFF, 0x01);
+    write_reg(0x4E, 0x2C);
+    write_reg(0x48, 0x00);
+    write_reg(0x30, 0x20);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x30, 0x09);
-    writeReg(0x54, 0x00);
-    writeReg(0x31, 0x04);
-    writeReg(0x32, 0x03);
-    writeReg(0x40, 0x83);
-    writeReg(0x46, 0x25);
-    writeReg(0x60, 0x00);
-    writeReg(0x27, 0x00);
-    writeReg(0x50, 0x06);
-    writeReg(0x51, 0x00);
-    writeReg(0x52, 0x96);
-    writeReg(0x56, 0x08);
-    writeReg(0x57, 0x30);
-    writeReg(0x61, 0x00);
-    writeReg(0x62, 0x00);
-    writeReg(0x64, 0x00);
-    writeReg(0x65, 0x00);
-    writeReg(0x66, 0xA0);
+    write_reg(0xFF, 0x00);
+    write_reg(0x30, 0x09);
+    write_reg(0x54, 0x00);
+    write_reg(0x31, 0x04);
+    write_reg(0x32, 0x03);
+    write_reg(0x40, 0x83);
+    write_reg(0x46, 0x25);
+    write_reg(0x60, 0x00);
+    write_reg(0x27, 0x00);
+    write_reg(0x50, 0x06);
+    write_reg(0x51, 0x00);
+    write_reg(0x52, 0x96);
+    write_reg(0x56, 0x08);
+    write_reg(0x57, 0x30);
+    write_reg(0x61, 0x00);
+    write_reg(0x62, 0x00);
+    write_reg(0x64, 0x00);
+    write_reg(0x65, 0x00);
+    write_reg(0x66, 0xA0);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x22, 0x32);
-    writeReg(0x47, 0x14);
-    writeReg(0x49, 0xFF);
-    writeReg(0x4A, 0x00);
+    write_reg(0xFF, 0x01);
+    write_reg(0x22, 0x32);
+    write_reg(0x47, 0x14);
+    write_reg(0x49, 0xFF);
+    write_reg(0x4A, 0x00);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x7A, 0x0A);
-    writeReg(0x7B, 0x00);
-    writeReg(0x78, 0x21);
+    write_reg(0xFF, 0x00);
+    write_reg(0x7A, 0x0A);
+    write_reg(0x7B, 0x00);
+    write_reg(0x78, 0x21);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x23, 0x34);
-    writeReg(0x42, 0x00);
-    writeReg(0x44, 0xFF);
-    writeReg(0x45, 0x26);
-    writeReg(0x46, 0x05);
-    writeReg(0x40, 0x40);
-    writeReg(0x0E, 0x06);
-    writeReg(0x20, 0x1A);
-    writeReg(0x43, 0x40);
+    write_reg(0xFF, 0x01);
+    write_reg(0x23, 0x34);
+    write_reg(0x42, 0x00);
+    write_reg(0x44, 0xFF);
+    write_reg(0x45, 0x26);
+    write_reg(0x46, 0x05);
+    write_reg(0x40, 0x40);
+    write_reg(0x0E, 0x06);
+    write_reg(0x20, 0x1A);
+    write_reg(0x43, 0x40);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x34, 0x03);
-    writeReg(0x35, 0x44);
+    write_reg(0xFF, 0x00);
+    write_reg(0x34, 0x03);
+    write_reg(0x35, 0x44);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x31, 0x04);
-    writeReg(0x4B, 0x09);
-    writeReg(0x4C, 0x05);
-    writeReg(0x4D, 0x04);
+    write_reg(0xFF, 0x01);
+    write_reg(0x31, 0x04);
+    write_reg(0x4B, 0x09);
+    write_reg(0x4C, 0x05);
+    write_reg(0x4D, 0x04);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x44, 0x00);
-    writeReg(0x45, 0x20);
-    writeReg(0x47, 0x08);
-    writeReg(0x48, 0x28);
-    writeReg(0x67, 0x00);
-    writeReg(0x70, 0x04);
-    writeReg(0x71, 0x01);
-    writeReg(0x72, 0xFE);
-    writeReg(0x76, 0x00);
-    writeReg(0x77, 0x00);
+    write_reg(0xFF, 0x00);
+    write_reg(0x44, 0x00);
+    write_reg(0x45, 0x20);
+    write_reg(0x47, 0x08);
+    write_reg(0x48, 0x28);
+    write_reg(0x67, 0x00);
+    write_reg(0x70, 0x04);
+    write_reg(0x71, 0x01);
+    write_reg(0x72, 0xFE);
+    write_reg(0x76, 0x00);
+    write_reg(0x77, 0x00);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x0D, 0x01);
+    write_reg(0xFF, 0x01);
+    write_reg(0x0D, 0x01);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x01);
-    writeReg(0x01, 0xF8);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x01);
+    write_reg(0x01, 0xF8);
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x8E, 0x01);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
+    write_reg(0xFF, 0x01);
+    write_reg(0x8E, 0x01);
+    write_reg(0x00, 0x01);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x00);
 
     // -- VL53L0X_load_tuning_settings() end
 
     // "Set interrupt config to new sample ready"
     // -- VL53L0X_SetGpioConfig() begin
 
-    writeReg(SYSTEM_INTERRUPT_CONFIG_GPIO, 0x04);
-    writeReg(GPIO_HV_MUX_ACTIVE_HIGH,
-             readReg(GPIO_HV_MUX_ACTIVE_HIGH) & ~0x10);  // active low
-    writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
+    write_reg(SYSTEM_INTERRUPT_CONFIG_GPIO, 0x04);
+    write_reg(GPIO_HV_MUX_ACTIVE_HIGH,
+              read_reg(GPIO_HV_MUX_ACTIVE_HIGH) & ~0x10);  // active low
+    write_reg(SYSTEM_INTERRUPT_CLEAR, 0x01);
 
     // -- VL53L0X_SetGpioConfig() end4
 
-    measurement_timing_budget_us = getMeasurementTimingBudget();
+    measurement_timing_budget_us = get_measurement_timing_budget();
 
     // "Disable MSRC and TCC by default"
     // MSRC = Minimum Signal Rate Check
     // TCC = Target CentreCheck
     // -- VL53L0X_SetSequenceStepEnable() begin
 
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0xE8);
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0xE8);
 
     // -- VL53L0X_SetSequenceStepEnable() end
 
     // "Recalculate timing budget"
-    setMeasurementTimingBudget(measurement_timing_budget_us);
+    set_measurement_timing_budget(measurement_timing_budget_us);
 
     // VL53L0X_StaticInit() end
 
@@ -517,74 +525,74 @@ uint8_t vl53l0x_init() {
 
     // -- VL53L0X_perform_vhv_calibration() begin
 
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0x01);
-    if (!performSingleRefCalibration(0x40))
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0x01);
+    if (!perform_single_ref_calibration(0x40))
         return 0;
 
     // -- VL53L0X_perform_vhv_calibration() end
 
     // -- VL53L0X_perform_phase_calibration() begin
 
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0x02);
-    if (!performSingleRefCalibration(0x00))
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0x02);
+    if (!perform_single_ref_calibration(0x00))
         return 0;
 
     // -- VL53L0X_perform_phase_calibration() end
 
     // "restore the previous Sequence Config"
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0xE8);
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0xE8);
 
     // VL53L0X_PerformRefCalibration() end
 
-    setVcselPulsePeriod(VcselPeriodPreRange, VL53L0X_VCSEL_PRE_RANGE);
-    setVcselPulsePeriod(VcselPeriodFinalRange, VL53L0X_VCSEL_FINAL_RANGE);
+    set_vcsel_pulse_period(VcselPeriodPreRange, VL53L0X_VCSEL_PRE_RANGE);
+    set_vcsel_pulse_period(VcselPeriodFinalRange, VL53L0X_VCSEL_FINAL_RANGE);
 
     return 1;
 }
 
-void vl53l0x_startContinuous(uint32_t period_ms) {
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, stop_variable);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
+void vl53l0x_start_continuous(uint32_t period_ms) {
+    write_reg(0x80, 0x01);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
+    write_reg(0x91, stop_variable);
+    write_reg(0x00, 0x01);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x00);
 
     if (period_ms != 0) {
         // continuous timed mode
         // VL53L0X_SetInterMeasurementPeriodMilliSeconds() begin
-        uint16_t osc_calibrate_val = readReg16(OSC_CALIBRATE_VAL);
+        uint16_t osc_calibrate_val = read_reg16(OSC_CALIBRATE_VAL);
         if (osc_calibrate_val != 0)
             period_ms *= osc_calibrate_val;
 
-        writeReg32(SYSTEM_INTERMEASUREMENT_PERIOD, period_ms);
+        write_reg32(SYSTEM_INTERMEASUREMENT_PERIOD, period_ms);
         // VL53L0X_SetInterMeasurementPeriodMilliSeconds() end
 
-        writeReg(SYSRANGE_START, 0x04);  // VL53L0X_REG_SYSRANGE_MODE_TIMED
+        write_reg(SYSRANGE_START, 0x04);  // VL53L0X_REG_SYSRANGE_MODE_TIMED
     } else {
         // continuous back-to-back mode
-        writeReg(SYSRANGE_START, 0x02);  // VL53L0X_REG_SYSRANGE_MODE_BACKTOBACK
+        write_reg(SYSRANGE_START, 0x02);  // VL53L0X_REG_SYSRANGE_MODE_BACKTOBACK
     }
 }
 
 // Stop continuous measurements
 // based on VL53L0X_StopMeasurement()
-void vl53l0x_stopContinuous() {
-    writeReg(SYSRANGE_START, 0x01);  // VL53L0X_REG_SYSRANGE_MODE_SINGLESHOT
+void vl53l0x_stop_continuous() {
+    write_reg(SYSRANGE_START, 0x01);  // VL53L0X_REG_SYSRANGE_MODE_SINGLESHOT
 
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, 0x00);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
+    write_reg(0x91, 0x00);
+    write_reg(0x00, 0x01);
+    write_reg(0xFF, 0x00);
 }
 
 // Returns a range reading in millimeters when continuous mode is active
-uint16_t vl53l0x_getRange() {
-    startTimeout();
-    while ((readReg(RESULT_INTERRUPT_STATUS) & 0x07) == 0) {
-        if (checkTimeoutExpired()) {
+uint16_t vl53l0x_get_range() {
+    start_timeout();
+    while ((read_reg(RESULT_INTERRUPT_STATUS) & 0x07) == 0) {
+        if (check_timeout_expired()) {
             did_timeout = 1;
             return VL53L0X_TIMEOUT_RETURN_VALUE;
         }
@@ -592,150 +600,155 @@ uint16_t vl53l0x_getRange() {
 
     // assumptions: Linearity Corrective Gain is 1000 (default);
     // fractional ranging is not enabled
-    uint16_t range = readReg16(RESULT_RANGE_STATUS + 10);
+    uint16_t range = read_reg16(RESULT_RANGE_STATUS + 10);
 
-    writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
+    write_reg(SYSTEM_INTERRUPT_CLEAR, 0x01);
 
     return range;
 }
 
-uint16_t vl53l0x_getRangeSingle() {
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
-    writeReg(0x91, stop_variable);
-    writeReg(0x00, 0x01);
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
+uint16_t vl53l0x_get_rangeSingle() {
+    write_reg(0x80, 0x01);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
+    write_reg(0x91, stop_variable);
+    write_reg(0x00, 0x01);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x00);
 
-    writeReg(SYSRANGE_START, 0x01);
+    write_reg(SYSRANGE_START, 0x01);
 
     // "Wait until start bit has been cleared"
-    startTimeout();
-    while (readReg(SYSRANGE_START) & 0x01) {
-        if (checkTimeoutExpired()) {
+    start_timeout();
+    while (read_reg(SYSRANGE_START) & 0x01) {
+        if (check_timeout_expired()) {
             did_timeout = 1;
             return VL53L0X_TIMEOUT_RETURN_VALUE;
         }
     }
 
-    return vl53l0x_getRange();
+    return vl53l0x_get_range();
 }
 
 /*****************************************
- * Public Function Body Definitions
+ * Private Function Body Definitions
  *****************************************/
 
-void writeReg(uint8_t reg, uint8_t val) {
+void write_reg(uint8_t reg, uint8_t val) {
     uint8_t bytes[2] = {reg, val};
 
-    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 2, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 2, VL53L0X_I2C_TIMEOUT) != HAL_OK)
         ;
 }
 
-void writeReg16(uint8_t reg, uint16_t val) {
+void write_reg16(uint8_t reg, uint16_t val) {
     uint8_t bytes[3] = {reg, (val >> 8) & 0xFF, val & 0xFF};
 
-    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 3, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 3, VL53L0X_I2C_TIMEOUT) != HAL_OK)
         ;
 }
 
-void writeReg32(uint8_t reg, uint32_t val) {
+void write_reg32(uint8_t reg, uint32_t val) {
     uint8_t bytes[5] = {reg, (val >> 24) & 0xFF, (val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF};
 
-    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), 5, VL53L0X_I2C_TIMEOUT) != HAL_OK)
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), 5, VL53L0X_I2C_TIMEOUT) != HAL_OK)
         ;
 }
 
-void writeMulti(uint8_t reg, uint8_t* src, uint8_t count) {
-    if (count > 31)
+void write_multi(uint8_t reg, uint8_t* src, uint8_t count) {
+    if (count > 31) {
         return;
+    }
 
     count++;
     uint8_t bytes[32] = {0};
     bytes[0] = reg;
-    for (uint8_t i = 1; i < count; i++)
+    for (uint8_t i = 1; i < count; i++) {
         bytes[i] = src[i - 1];
+    }
 
-    while (HAL_I2C_Master_Transmit(&VL53L0X_I2C_HANDLER, address, (uint8_t*)(&bytes), count, VL53L0X_I2C_TIMEOUT) !=
-           HAL_OK)
+    while (HAL_I2C_Master_Transmit(i2c_handler, address, (uint8_t*) (&bytes), count, VL53L0X_I2C_TIMEOUT) != HAL_OK)
         ;
 }
 
-uint8_t readReg(uint8_t reg) {
+uint8_t read_reg(uint8_t reg) {
     uint8_t val;
 
-    if ((status = HAL_I2C_Mem_Read(&VL53L0X_I2C_HANDLER, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1,
-                                   VL53L0X_I2C_TIMEOUT)) != HAL_OK)
+    if ((status = HAL_I2C_Mem_Read(i2c_handler, address, reg, I2C_MEMADD_SIZE_8BIT, &val, 1, VL53L0X_I2C_TIMEOUT)) !=
+        HAL_OK) {
         return 0;
+    }
 
     return val;
 }
 
-uint16_t readReg16(uint8_t reg) {
+uint16_t read_reg16(uint8_t reg) {
     uint8_t val[2];
-    readMulti(reg, val, 2);
-    return (uint16_t)val[0] << 8 | val[1];
+    read_multi(reg, val, 2);
+
+    return (uint16_t) val[0] << 8 | val[1];
 }
 
-uint32_t readReg32(uint8_t reg) {
+uint32_t read_reg32(uint8_t reg) {
     uint8_t val[4];
-    readMulti(reg, val, 4);
+    read_multi(reg, val, 4);
 
-    return (uint32_t)val[0] << 24 | (uint32_t)val[1] << 16 | (uint16_t)val[2] << 8 | val[3];
+    return (uint32_t) val[0] << 24 | (uint32_t) val[1] << 16 | (uint16_t) val[2] << 8 | val[3];
 }
 
-void readMulti(uint8_t reg, uint8_t* dst, uint8_t count) {
-    HAL_I2C_Mem_Read(&VL53L0X_I2C_HANDLER, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, VL53L0X_I2C_TIMEOUT);
+void read_multi(uint8_t reg, uint8_t* dst, uint8_t count) {
+    HAL_I2C_Mem_Read(i2c_handler, address, reg, I2C_MEMADD_SIZE_8BIT, dst, count, VL53L0X_I2C_TIMEOUT);
 }
 
-uint8_t getSpadInfo(uint8_t* count, uint8_t* type_is_aperture) {
+uint8_t get_spad_info(uint8_t* count, uint8_t* type_is_aperture) {
     uint8_t temp;
 
-    writeReg(0x80, 0x01);
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x00);
+    write_reg(0x80, 0x01);
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x00);
 
-    writeReg(0xFF, 0x06);
-    writeReg(0x83, readReg(0x83) | 0x04);
-    writeReg(0xFF, 0x07);
-    writeReg(0x81, 0x01);
+    write_reg(0xFF, 0x06);
+    write_reg(0x83, read_reg(0x83) | 0x04);
+    write_reg(0xFF, 0x07);
+    write_reg(0x81, 0x01);
 
-    writeReg(0x80, 0x01);
+    write_reg(0x80, 0x01);
 
-    writeReg(0x94, 0x6b);
-    writeReg(0x83, 0x00);
-    startTimeout();
-    while (readReg(0x83) == 0x00)
-        if (checkTimeoutExpired())
+    write_reg(0x94, 0x6b);
+    write_reg(0x83, 0x00);
+    start_timeout();
+    while (read_reg(0x83) == 0x00) {
+        if (check_timeout_expired()) {
             return 0;
+        }
+    }
 
-    writeReg(0x83, 0x01);
-    temp = readReg(0x92);
+    write_reg(0x83, 0x01);
+    temp = read_reg(0x92);
 
     *count = temp & 0x7F;
     *type_is_aperture = (temp >> 7) & 0x01;
 
-    writeReg(0x81, 0x00);
-    writeReg(0xFF, 0x06);
-    writeReg(0x83, readReg(0x83 & ~0x04));
-    writeReg(0xFF, 0x01);
-    writeReg(0x00, 0x01);
+    write_reg(0x81, 0x00);
+    write_reg(0xFF, 0x06);
+    write_reg(0x83, read_reg(0x83 & ~0x04));
+    write_reg(0xFF, 0x01);
+    write_reg(0x00, 0x01);
 
-    writeReg(0xFF, 0x00);
-    writeReg(0x80, 0x00);
+    write_reg(0xFF, 0x00);
+    write_reg(0x80, 0x00);
 
     return 1;
 }
 
-uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
+uint8_t set_vcsel_pulse_period(vcselPeriodType type, uint8_t period_pclks) {
     uint8_t vcsel_period_reg = encodeVcselPeriod(period_pclks);
 
     SequenceStepEnables enables;
     SequenceStepTimeouts timeouts;
 
-    getSequenceStepEnables(&enables);
-    getSequenceStepTimeouts(&enables, &timeouts);
+    get_sequence_step_enables(&enables);
+    get_sequence_step_timeouts(&enables, &timeouts);
 
     // "Apply specific settings for the requested clock period"
     // "Re-calculate and apply timeouts, in macro periods"
@@ -753,89 +766,89 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         // "Set phase check limits"
         switch (period_pclks) {
             case 12:
-                writeReg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x18);
+                write_reg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x18);
                 break;
 
             case 14:
-                writeReg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x30);
+                write_reg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x30);
                 break;
 
             case 16:
-                writeReg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x40);
+                write_reg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x40);
                 break;
 
             case 18:
-                writeReg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x50);
+                write_reg(PRE_RANGE_CONFIG_VALID_PHASE_HIGH, 0x50);
                 break;
 
             default:
                 // invalid period
                 return 0;
         }
-        writeReg(PRE_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
+        write_reg(PRE_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
 
         // apply new VCSEL period
-        writeReg(PRE_RANGE_CONFIG_VCSEL_PERIOD, vcsel_period_reg);
+        write_reg(PRE_RANGE_CONFIG_VCSEL_PERIOD, vcsel_period_reg);
 
         // update timeouts
 
         // set_sequence_step_timeout() begin
         // (SequenceStepId == VL53L0X_SEQUENCESTEP_PRE_RANGE)
 
-        uint16_t new_pre_range_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.pre_range_us, period_pclks);
+        uint16_t new_pre_range_timeout_mclks = timeout_microseconds_to_mclks(timeouts.pre_range_us, period_pclks);
 
-        writeReg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(new_pre_range_timeout_mclks));
+        write_reg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI, encode_timeout(new_pre_range_timeout_mclks));
 
         // set_sequence_step_timeout() end
 
         // set_sequence_step_timeout() begin
         // (SequenceStepId == VL53L0X_SEQUENCESTEP_MSRC)
 
-        uint16_t new_msrc_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.msrc_dss_tcc_us, period_pclks);
+        uint16_t new_msrc_timeout_mclks = timeout_microseconds_to_mclks(timeouts.msrc_dss_tcc_us, period_pclks);
 
-        writeReg(MSRC_CONFIG_TIMEOUT_MACROP, (new_msrc_timeout_mclks > 256) ? 255 : (new_msrc_timeout_mclks - 1));
+        write_reg(MSRC_CONFIG_TIMEOUT_MACROP, (new_msrc_timeout_mclks > 256) ? 255 : (new_msrc_timeout_mclks - 1));
 
         // set_sequence_step_timeout() end
     } else if (type == VcselPeriodFinalRange) {
         switch (period_pclks) {
             case 8:
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x10);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
-                writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x02);
-                writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x0C);
-                writeReg(0xFF, 0x01);
-                writeReg(ALGO_PHASECAL_LIM, 0x30);
-                writeReg(0xFF, 0x00);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x10);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
+                write_reg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x02);
+                write_reg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x0C);
+                write_reg(0xFF, 0x01);
+                write_reg(ALGO_PHASECAL_LIM, 0x30);
+                write_reg(0xFF, 0x00);
                 break;
 
             case 10:
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x28);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
-                writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
-                writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x09);
-                writeReg(0xFF, 0x01);
-                writeReg(ALGO_PHASECAL_LIM, 0x20);
-                writeReg(0xFF, 0x00);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x28);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
+                write_reg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
+                write_reg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x09);
+                write_reg(0xFF, 0x01);
+                write_reg(ALGO_PHASECAL_LIM, 0x20);
+                write_reg(0xFF, 0x00);
                 break;
 
             case 12:
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x38);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
-                writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
-                writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x08);
-                writeReg(0xFF, 0x01);
-                writeReg(ALGO_PHASECAL_LIM, 0x20);
-                writeReg(0xFF, 0x00);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x38);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
+                write_reg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
+                write_reg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x08);
+                write_reg(0xFF, 0x01);
+                write_reg(ALGO_PHASECAL_LIM, 0x20);
+                write_reg(0xFF, 0x00);
                 break;
 
             case 14:
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x48);
-                writeReg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
-                writeReg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
-                writeReg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x07);
-                writeReg(0xFF, 0x01);
-                writeReg(ALGO_PHASECAL_LIM, 0x20);
-                writeReg(0xFF, 0x00);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_HIGH, 0x48);
+                write_reg(FINAL_RANGE_CONFIG_VALID_PHASE_LOW, 0x08);
+                write_reg(GLOBAL_CONFIG_VCSEL_WIDTH, 0x03);
+                write_reg(ALGO_PHASECAL_CONFIG_TIMEOUT, 0x07);
+                write_reg(0xFF, 0x01);
+                write_reg(ALGO_PHASECAL_LIM, 0x20);
+                write_reg(0xFF, 0x00);
                 break;
 
             default:
@@ -844,7 +857,7 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         }
 
         // apply new VCSEL period
-        writeReg(FINAL_RANGE_CONFIG_VCSEL_PERIOD, vcsel_period_reg);
+        write_reg(FINAL_RANGE_CONFIG_VCSEL_PERIOD, vcsel_period_reg);
 
         // update timeouts
 
@@ -856,12 +869,13 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
         //  timeouts must be expressed in macro periods MClks
         //  because they have different vcsel periods."
 
-        uint16_t new_final_range_timeout_mclks = timeoutMicrosecondsToMclks(timeouts.final_range_us, period_pclks);
+        uint16_t new_final_range_timeout_mclks = timeout_microseconds_to_mclks(timeouts.final_range_us, period_pclks);
 
-        if (enables.pre_range)
+        if (enables.pre_range) {
             new_final_range_timeout_mclks += timeouts.pre_range_mclks;
+        }
 
-        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(new_final_range_timeout_mclks));
+        write_reg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encode_timeout(new_final_range_timeout_mclks));
 
         // set_sequence_step_timeout end
     } else {
@@ -871,31 +885,31 @@ uint8_t setVcselPulsePeriod(vcselPeriodType type, uint8_t period_pclks) {
 
     // "Finally, the timing budget must be re-applied"
 
-    setMeasurementTimingBudget(measurement_timing_budget_us);
+    set_measurement_timing_budget(measurement_timing_budget_us);
 
     // "Perform the phase calibration. This is needed after changing on vcsel
     // period." VL53L0X_perform_phase_calibration() begin
 
-    uint8_t sequence_config = readReg(SYSTEM_SEQUENCE_CONFIG);
-    writeReg(SYSTEM_SEQUENCE_CONFIG, 0x02);
-    performSingleRefCalibration(0x0);
-    writeReg(SYSTEM_SEQUENCE_CONFIG, sequence_config);
+    uint8_t sequence_config = read_reg(SYSTEM_SEQUENCE_CONFIG);
+    write_reg(SYSTEM_SEQUENCE_CONFIG, 0x02);
+    perform_single_ref_calibration(0x0);
+    write_reg(SYSTEM_SEQUENCE_CONFIG, sequence_config);
 
     // VL53L0X_perform_phase_calibration() end
 
     return 1;
 }
 
-uint8_t getVcselPulsePeriod(vcselPeriodType type) {
-    if (type == VcselPeriodPreRange)
-        return decodeVcselPeriod(readReg(PRE_RANGE_CONFIG_VCSEL_PERIOD));
-    else if (type == VcselPeriodFinalRange)
-        return decodeVcselPeriod(readReg(FINAL_RANGE_CONFIG_VCSEL_PERIOD));
-    else
-        return 255;
+uint8_t get_vcsel_pulse_period(vcselPeriodType type) {
+    if (type == VcselPeriodPreRange) {
+        return decodeVcselPeriod(read_reg(PRE_RANGE_CONFIG_VCSEL_PERIOD));
+    } else if (type == VcselPeriodFinalRange) {
+        return decodeVcselPeriod(read_reg(FINAL_RANGE_CONFIG_VCSEL_PERIOD));
+    }
+    return 255;
 }
 
-uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
+uint8_t set_measurement_timing_budget(uint32_t budget_us) {
     SequenceStepEnables enables;
     SequenceStepTimeouts timeouts;
 
@@ -909,24 +923,28 @@ uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
 
     const uint32_t MinTimingBudget = 20000;
 
-    if (budget_us < MinTimingBudget)
+    if (budget_us < MinTimingBudget) {
         return 0;
+    }
 
     uint32_t used_budget_us = StartOverhead + EndOverhead;
 
-    getSequenceStepEnables(&enables);
-    getSequenceStepTimeouts(&enables, &timeouts);
+    get_sequence_step_enables(&enables);
+    get_sequence_step_timeouts(&enables, &timeouts);
 
-    if (enables.tcc)
+    if (enables.tcc) {
         used_budget_us += (timeouts.msrc_dss_tcc_us + TccOverhead);
+    }
 
-    if (enables.dss)
+    if (enables.dss) {
         used_budget_us += 2 * (timeouts.msrc_dss_tcc_us + DssOverhead);
-    else if (enables.msrc)
+    } else if (enables.msrc) {
         used_budget_us += (timeouts.msrc_dss_tcc_us + MsrcOverhead);
+    }
 
-    if (enables.pre_range)
+    if (enables.pre_range) {
         used_budget_us += (timeouts.pre_range_us + PreRangeOverhead);
+    }
 
     if (enables.final_range) {
         used_budget_us += FinalRangeOverhead;
@@ -953,12 +971,13 @@ uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
         //  because they have different vcsel periods."
 
         uint16_t final_range_timeout_mclks =
-            timeoutMicrosecondsToMclks(final_range_timeout_us, timeouts.final_range_vcsel_period_pclks);
+            timeout_microseconds_to_mclks(final_range_timeout_us, timeouts.final_range_vcsel_period_pclks);
 
-        if (enables.pre_range)
+        if (enables.pre_range) {
             final_range_timeout_mclks += timeouts.pre_range_mclks;
+        }
 
-        writeReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encodeTimeout(final_range_timeout_mclks));
+        write_reg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI, encode_timeout(final_range_timeout_mclks));
 
         // set_sequence_step_timeout() end
 
@@ -967,7 +986,7 @@ uint8_t setMeasurementTimingBudget(uint32_t budget_us) {
     return 1;
 }
 
-uint32_t getMeasurementTimingBudget() {
+uint32_t get_measurement_timing_budget() {
     SequenceStepEnables enables;
     SequenceStepTimeouts timeouts;
 
@@ -982,29 +1001,33 @@ uint32_t getMeasurementTimingBudget() {
     // "Start and end overhead times always present"
     uint32_t budget_us = StartOverhead + EndOverhead;
 
-    getSequenceStepEnables(&enables);
-    getSequenceStepTimeouts(&enables, &timeouts);
+    get_sequence_step_enables(&enables);
+    get_sequence_step_timeouts(&enables, &timeouts);
 
-    if (enables.tcc)
+    if (enables.tcc) {
         budget_us += (timeouts.msrc_dss_tcc_us + TccOverhead);
+    }
 
-    if (enables.dss)
+    if (enables.dss) {
         budget_us += 2 * (timeouts.msrc_dss_tcc_us + DssOverhead);
-    else if (enables.msrc)
+    } else if (enables.msrc) {
         budget_us += (timeouts.msrc_dss_tcc_us + MsrcOverhead);
+    }
 
-    if (enables.pre_range)
+    if (enables.pre_range) {
         budget_us += (timeouts.pre_range_us + PreRangeOverhead);
+    }
 
-    if (enables.final_range)
+    if (enables.final_range) {
         budget_us += (timeouts.final_range_us + FinalRangeOverhead);
+    }
 
     measurement_timing_budget_us = budget_us;  // store for internal reuse
     return budget_us;
 }
 
-void getSequenceStepEnables(SequenceStepEnables* enables) {
-    uint8_t sequence_config = readReg(SYSTEM_SEQUENCE_CONFIG);
+void get_sequence_step_enables(SequenceStepEnables* enables) {
+    uint8_t sequence_config = read_reg(SYSTEM_SEQUENCE_CONFIG);
 
     enables->tcc = (sequence_config >> 4) & 0x1;
     enables->dss = (sequence_config >> 3) & 0x1;
@@ -1013,70 +1036,74 @@ void getSequenceStepEnables(SequenceStepEnables* enables) {
     enables->final_range = (sequence_config >> 7) & 0x1;
 }
 
-void getSequenceStepTimeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts) {
-    timeouts->pre_range_vcsel_period_pclks = getVcselPulsePeriod(VcselPeriodPreRange);
-    timeouts->msrc_dss_tcc_mclks = readReg(MSRC_CONFIG_TIMEOUT_MACROP) + 1;
+void get_sequence_step_timeouts(SequenceStepEnables* enables, SequenceStepTimeouts* timeouts) {
+    timeouts->pre_range_vcsel_period_pclks = get_vcsel_pulse_period(VcselPeriodPreRange);
+    timeouts->msrc_dss_tcc_mclks = read_reg(MSRC_CONFIG_TIMEOUT_MACROP) + 1;
     timeouts->msrc_dss_tcc_us =
-        timeoutMclksToMicroseconds(timeouts->msrc_dss_tcc_mclks, timeouts->pre_range_vcsel_period_pclks);
-    timeouts->pre_range_mclks = decodeTimeout(readReg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI));
+        timeout_mclks_to_microseconds(timeouts->msrc_dss_tcc_mclks, timeouts->pre_range_vcsel_period_pclks);
+    timeouts->pre_range_mclks = decode_timeout(read_reg16(PRE_RANGE_CONFIG_TIMEOUT_MACROP_HI));
     timeouts->pre_range_us =
-        timeoutMclksToMicroseconds(timeouts->pre_range_mclks, timeouts->pre_range_vcsel_period_pclks);
-    timeouts->final_range_vcsel_period_pclks = getVcselPulsePeriod(VcselPeriodFinalRange);
-    timeouts->final_range_mclks = decodeTimeout(readReg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI));
+        timeout_mclks_to_microseconds(timeouts->pre_range_mclks, timeouts->pre_range_vcsel_period_pclks);
+    timeouts->final_range_vcsel_period_pclks = get_vcsel_pulse_period(VcselPeriodFinalRange);
+    timeouts->final_range_mclks = decode_timeout(read_reg16(FINAL_RANGE_CONFIG_TIMEOUT_MACROP_HI));
 
     if (enables->pre_range)
         timeouts->final_range_mclks -= timeouts->pre_range_mclks;
 
     timeouts->final_range_us =
-        timeoutMclksToMicroseconds(timeouts->final_range_mclks, timeouts->final_range_vcsel_period_pclks);
+        timeout_mclks_to_microseconds(timeouts->final_range_mclks, timeouts->final_range_vcsel_period_pclks);
 }
 
-uint16_t decodeTimeout(uint16_t reg_val) {
+uint16_t decode_timeout(uint16_t reg_val) {
     // format: "(LSByte * 2^MSByte) + 1"
     return (uint16_t)((reg_val & 0x00FF) << (uint16_t)((reg_val & 0xFF00) >> 8)) + 1;
 }
 
-uint16_t encodeTimeout(uint16_t timeout_mclks) {
+uint16_t encode_timeout(uint16_t timeout_mclks) {
     // format: "(LSByte * 2^MSByte) + 1"
     uint32_t ls_byte = 0;
     uint16_t ms_byte = 0;
 
     if (timeout_mclks > 0) {
         ls_byte = timeout_mclks - 1;
+
         while ((ls_byte & 0xFFFFFF00) > 0) {
             ls_byte >>= 1;
             ms_byte++;
         }
 
         return (ms_byte << 8) | (ls_byte & 0xFF);
-    } else {
-        return 0;
     }
+
+    return 0;
 }
 
-uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks) {
+uint32_t timeout_mclks_to_microseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks) {
     uint32_t macro_period_ns = calcMacroPeriod(vcsel_period_pclks);
 
     return ((timeout_period_mclks * macro_period_ns) + (macro_period_ns / 2)) / 1000;
 }
 
-uint32_t timeoutMicrosecondsToMclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks) {
+uint32_t timeout_microseconds_to_mclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks) {
     uint32_t macro_period_ns = calcMacroPeriod(vcsel_period_pclks);
 
     return (((timeout_period_us * 1000) + (macro_period_ns / 2)) / macro_period_ns);
 }
 
-uint8_t performSingleRefCalibration(uint8_t vhv_init_byte) {
-    writeReg(SYSRANGE_START,
-             0x01 | vhv_init_byte);  // VL53L0X_REG_SYSRANGE_MODE_START_STOP
+uint8_t perform_single_ref_calibration(uint8_t vhv_init_byte) {
+    write_reg(SYSRANGE_START,
+              0x01 | vhv_init_byte);  // VL53L0X_REG_SYSRANGE_MODE_START_STOP
 
-    startTimeout();
-    while ((readReg(RESULT_INTERRUPT_STATUS) & 0x07) == 0)
-        if (checkTimeoutExpired())
+    start_timeout();
+    
+    while ((read_reg(RESULT_INTERRUPT_STATUS) & 0x07) == 0) {
+        if (check_timeout_expired()) {
             return 0;
+        }
+    }
 
-    writeReg(SYSTEM_INTERRUPT_CLEAR, 0x01);
-    writeReg(SYSRANGE_START, 0x00);
+    write_reg(SYSTEM_INTERRUPT_CLEAR, 0x01);
+    write_reg(SYSRANGE_START, 0x00);
 
     return 1;
 }

--- a/VL53L0X/vl53l0x.h
+++ b/VL53L0X/vl53l0x.h
@@ -13,7 +13,9 @@
 #ifndef __VL53L0X_H__
 #define __VL53L0X_H__
 
-// SPECIFIC INCLUDES HERE
+#include <stdint.h>
+
+#include "i2c.h"
 
 /*****************************************
  * Public Constants
@@ -22,22 +24,23 @@
 #define VL53L0X_DEFAULT_ADDRESS (0x52)       /**< Default sensor address, don't change */
 #define VL53L0X_TIMEOUT_RETURN_VALUE (65535) /**< Value returned if getRange times out */
 
-#define VL53L0X_I2C_HANDLER hi2c1 /**< I2C handler */
-
-//! @see setVcselPulsePeriod
-#define VL53L0X_VCSEL_PRE_RANGE 18
-#define VL53L0X_VCSEL_FINAL_RANGE 14
-
 /*****************************************
  * Public Function Prototypes
  *****************************************/
 
 /**
+ * @brief Sets I2C handler for VL53L0X devices.
+ *
+ * @note This must be called first.
+ */
+void vl53l0x_i2c_set(I2C_HandleTypeDef* hi2c);
+
+/**
  * @brief Initializes a single VL53L0X device.
  *
  * @note This must be called before any other function,
- *       be sure only one uninitialized sensor is active
- *       through XSHUT pin.
+ *       except vl53l0x_i2c_set. Be sure only one
+ *       uninitialized sensor is active through XSHUT pin.
  *
  * @return 0 on failure, 1 on success.
  */
@@ -48,7 +51,7 @@ uint8_t vl53l0x_init();
  *
  * @param new_addr 8 bit address to be set
  */
-void vl53l0x_setDevAddress(uint8_t new_addr);
+void vl53l0x_set_dev_address(uint8_t new_addr);
 
 /**
  * @brief Change the current working address.
@@ -58,27 +61,27 @@ void vl53l0x_setDevAddress(uint8_t new_addr);
  *
  * @param new_addr 8 bit address to be set
  */
-void vl53l0x_setCurrentAddress(uint8_t new_addr);
+void vl53l0x_set_current_address(uint8_t new_addr);
 
 /**
  * @brief Start current device continuous measuring.
  *
  * @param period_ms Measuring period
  */
-void vl53l0x_startContinuous(uint32_t period_ms);
+void vl53l0x_start_continuous(uint32_t period_ms);
 
 /**
  * @brief Stop current device continuous measuring.
  */
-void vl53l0x_stopContinuous();
+void vl53l0x_stop_continuous();
 
 /**
  * @brief Get the current device's last measured range.
  *
- * @note vl53l0x_startContinuous must be called first.
+ * @note vl53l0x_start_continuous must be called first.
  *
  * @return Range in millimeters or 65535 on failure.
  */
-uint16_t vl53l0x_getRange();
+uint16_t vl53l0x_get_range();
 
 #endif  // __VL53L0X_H__


### PR DESCRIPTION
- Remove the need to modify header file.
  - Remove VL53L0X_I2C_HANDLER, VL53L0X_VCSEL_PRE_RANGE,
    VL53L0X_VCSEL_FINAL_RANGE constants;
  - Add vl53l0x_i2c_set function to set I2C handler.
- Change function names to snake_case.